### PR TITLE
Add common skills install script

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,118 @@
+param(
+  [string]$CloneDir,
+  [switch]$Help
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoUrl = "https://github.com/warpdotdev/common-skills/"
+$DestSkillsDir = Join-Path $HOME ".agents\skills"
+$CleanupCloneDir = $false
+
+function Show-Usage {
+  Write-Output "Usage: ./install.ps1 [-CloneDir DIR]"
+  Write-Output ""
+  Write-Output "Clone common-skills and copy its skills into $DestSkillsDir."
+  Write-Output ""
+  Write-Output "Options:"
+  Write-Output "  -CloneDir DIR   Directory to clone common-skills into."
+  Write-Output "  -Help           Show this help message."
+}
+
+function Should-OverwriteSkill {
+  param([string]$SkillName)
+
+  while ($true) {
+    $response = Read-Host "Skill '$SkillName' already exists. Overwrite it? [y/N]"
+
+    switch -Regex ($response) {
+      '^(y|yes)$' {
+        return $true
+      }
+      '^$|^(n|no)$' {
+        return $false
+      }
+      default {
+        Write-Output "Please answer yes or no."
+      }
+    }
+  }
+}
+
+if ($Help) {
+  Show-Usage
+  exit 0
+}
+
+if ([string]::IsNullOrWhiteSpace($CloneDir)) {
+  $CloneDir = Join-Path ([System.IO.Path]::GetTempPath()) ("common-skills." + [System.Guid]::NewGuid().ToString("N"))
+  $CleanupCloneDir = $true
+}
+
+try {
+  if (Test-Path -LiteralPath $CloneDir) {
+    if (-not (Test-Path -LiteralPath $CloneDir -PathType Container)) {
+      Write-Error "error: clone path already exists and is not a directory: $CloneDir"
+      exit 1
+    }
+
+    if ((Get-ChildItem -LiteralPath $CloneDir -Force | Select-Object -First 1) -ne $null) {
+      Write-Error "error: clone directory already exists and is not empty: $CloneDir"
+      exit 1
+    }
+  }
+
+  New-Item -ItemType Directory -Path $CloneDir -Force | Out-Null
+  git clone --depth 1 $RepoUrl $CloneDir
+
+  $SourceSkillsDir = Join-Path $CloneDir ".agents\skills"
+
+  if (-not (Test-Path -LiteralPath $SourceSkillsDir -PathType Container)) {
+    Write-Error "error: cloned repo does not contain $SourceSkillsDir"
+    exit 1
+  }
+
+  New-Item -ItemType Directory -Path $DestSkillsDir -Force | Out-Null
+
+  $InstalledSkills = @()
+  $SkippedSkills = @()
+
+  foreach ($SourceSkillDir in (Get-ChildItem -LiteralPath $SourceSkillsDir -Directory | Sort-Object Name)) {
+    $SkillName = $SourceSkillDir.Name
+    $DestSkillDir = Join-Path $DestSkillsDir $SkillName
+
+    if (Test-Path -LiteralPath $DestSkillDir) {
+      if (-not (Should-OverwriteSkill -SkillName $SkillName)) {
+        $SkippedSkills += $SkillName
+        continue
+      }
+
+      Remove-Item -LiteralPath $DestSkillDir -Recurse -Force
+    }
+
+    Copy-Item -LiteralPath $SourceSkillDir.FullName -Destination $DestSkillsDir -Recurse
+    $InstalledSkills += $SkillName
+  }
+
+  Write-Output "Installed common-skills into $DestSkillsDir"
+
+  if ($InstalledSkills.Count -gt 0) {
+    Write-Output "Installed skills:"
+    $InstalledSkills | ForEach-Object {
+      Write-Output "  - $_"
+    }
+  } else {
+    Write-Output "No skills installed."
+  }
+
+  if ($SkippedSkills.Count -gt 0) {
+    Write-Output "Skipped existing skills:"
+    $SkippedSkills | ForEach-Object {
+      Write-Output "  - $_"
+    }
+  }
+} finally {
+  if ($CleanupCloneDir -and (Test-Path -LiteralPath $CloneDir)) {
+    Remove-Item -LiteralPath $CloneDir -Recurse -Force
+  }
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -77,10 +77,57 @@ if [[ ! -d "${SOURCE_SKILLS_DIR}" ]]; then
 fi
 
 mkdir -p "${DEST_SKILLS_DIR}"
-cp -R "${SOURCE_SKILLS_DIR}/." "${DEST_SKILLS_DIR}/"
+
+should_overwrite_skill() {
+  local skill_name="$1"
+  local response=""
+
+  while true; do
+    read -r -p "Skill '${skill_name}' already exists. Overwrite it? [y/N] " response
+    case "${response}" in
+      [yY]|[yY][eE][sS])
+        return 0
+        ;;
+      ""|[nN]|[nN][oO])
+        return 1
+        ;;
+      *)
+        echo "Please answer yes or no."
+        ;;
+    esac
+  done
+}
+
+installed_skills=()
+skipped_skills=()
+
+while IFS= read -r skill_name; do
+  source_skill_dir="${SOURCE_SKILLS_DIR}/${skill_name}"
+  dest_skill_dir="${DEST_SKILLS_DIR}/${skill_name}"
+
+  if [[ -e "${dest_skill_dir}" ]]; then
+    if ! should_overwrite_skill "${skill_name}"; then
+      skipped_skills+=("${skill_name}")
+      continue
+    fi
+
+    rm -rf "${dest_skill_dir}"
+  fi
+
+  cp -R "${source_skill_dir}" "${dest_skill_dir}"
+  installed_skills+=("${skill_name}")
+done < <(find "${SOURCE_SKILLS_DIR}" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort)
 
 echo "Installed common-skills into ${DEST_SKILLS_DIR}"
-echo "Installed skills:"
-find "${SOURCE_SKILLS_DIR}" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort | while read -r skill_name; do
-  echo "  - ${skill_name}"
-done
+
+if [[ "${#installed_skills[@]}" -gt 0 ]]; then
+  echo "Installed skills:"
+  printf '  - %s\n' "${installed_skills[@]}"
+else
+  echo "No skills installed."
+fi
+
+if [[ "${#skipped_skills[@]}" -gt 0 ]]; then
+  echo "Skipped existing skills:"
+  printf '  - %s\n' "${skipped_skills[@]}"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_URL="https://github.com/warpdotdev/common-skills/"
+DEST_SKILLS_DIR="${HOME}/.agents/skills"
+CLONE_DIR=""
+CLEANUP_CLONE_DIR=0
+
+usage() {
+  cat <<EOF
+Usage: ./install.sh [--clone-dir DIR]
+
+Clone common-skills and copy its skills into ${DEST_SKILLS_DIR}.
+
+Options:
+  -d, --clone-dir DIR   Directory to clone common-skills into.
+  -h, --help            Show this help message.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -d|--clone-dir)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "error: --clone-dir requires a directory" >&2
+        exit 1
+      fi
+      CLONE_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${CLONE_DIR}" ]]; then
+  CLONE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/common-skills.XXXXXX")"
+  CLEANUP_CLONE_DIR=1
+fi
+
+cleanup() {
+  if [[ "${CLEANUP_CLONE_DIR}" -eq 1 ]]; then
+    rm -rf "${CLONE_DIR}"
+  fi
+}
+
+trap cleanup EXIT
+
+if [[ -e "${CLONE_DIR}" ]]; then
+  if [[ ! -d "${CLONE_DIR}" ]]; then
+    echo "error: clone path already exists and is not a directory: ${CLONE_DIR}" >&2
+    exit 1
+  fi
+
+  if [[ -n "$(ls -A "${CLONE_DIR}")" ]]; then
+    echo "error: clone directory already exists and is not empty: ${CLONE_DIR}" >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "${CLONE_DIR}"
+git clone --depth 1 "${REPO_URL}" "${CLONE_DIR}"
+
+SOURCE_SKILLS_DIR="${CLONE_DIR}/.agents/skills"
+
+if [[ ! -d "${SOURCE_SKILLS_DIR}" ]]; then
+  echo "error: cloned repo does not contain ${SOURCE_SKILLS_DIR}" >&2
+  exit 1
+fi
+
+mkdir -p "${DEST_SKILLS_DIR}"
+cp -R "${SOURCE_SKILLS_DIR}/." "${DEST_SKILLS_DIR}/"
+
+echo "Installed common-skills into ${DEST_SKILLS_DIR}"
+echo "Installed skills:"
+find "${SOURCE_SKILLS_DIR}" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort | while read -r skill_name; do
+  echo "  - ${skill_name}"
+done


### PR DESCRIPTION
## Summary
- Add scripts/install.sh to clone warpdotdev/common-skills and install its skills globally into ~/.agents/skills
- Support an optional --clone-dir flag while defaulting to a temporary clone directory
- Print each installed skill after copying

## Validation
- bash -n scripts/install.sh
- ./scripts/install.sh

Conversation: https://staging.warp.dev/conversation/2ef9daea-5ad6-4162-b066-1fe6562ec568

Co-Authored-By: Oz <oz-agent@warp.dev>