### PR TITLE
Support custom skill install destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ To clone into a specific temporary directory instead of using an automatically c
 ./scripts/install.sh --clone-dir /path/to/empty/clone-dir
 ```
 
+To install into a repository-local skills directory instead of `~/.agents/skills`, run:
+
+```sh
+./scripts/install.sh --dest-dir /path/to/repo/.agents/skills
+```
+
+When using the piped installer, pass installer arguments after `bash -s --`:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/warpdotdev/common-skills/main/scripts/install.sh | bash -s -- --dest-dir /path/to/repo/.agents/skills
+```
+
 ### Windows
 
 Run the PowerShell installer:
@@ -93,7 +105,13 @@ To clone into a specific temporary directory instead of using an automatically c
 .\scripts\install.ps1 -CloneDir C:\path\to\empty\clone-dir
 ```
 
-Both installers clone this repository, copy each skill directory from `.agents/skills/` into `~/.agents/skills`, and prompt before overwriting an existing skill with the same name. If you decline the prompt, that skill is skipped and the installer continues.
+To install into a repository-local skills directory instead of `~/.agents\skills`, run:
+
+```powershell
+.\scripts\install.ps1 -DestSkillsDir C:\path\to\repo\.agents\skills
+```
+
+Both installers clone this repository, copy each skill directory from `.agents/skills/` into the destination skills directory, and prompt before overwriting an existing skill with the same name. If you decline the prompt, that skill is skipped and the installer continues.
 
 You can also copy or sync selected directories from `.agents/skills/` into a repository's own `.agents/skills/` directory.
 

--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ To clone into a specific temporary directory instead of using an automatically c
 To install into a repository-local skills directory instead of `~/.agents/skills`, run:
 
 ```sh
-./scripts/install.sh --dest-dir /path/to/repo/.agents/skills
+./scripts/install.sh --dest-dir /path/to/repo
 ```
 
 When using the piped installer, pass installer arguments after `bash -s --`:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/warpdotdev/common-skills/main/scripts/install.sh | bash -s -- --dest-dir /path/to/repo/.agents/skills
+curl -fsSL https://raw.githubusercontent.com/warpdotdev/common-skills/main/scripts/install.sh | bash -s -- --dest-dir /path/to/repo
 ```
 
 ### Windows
@@ -108,7 +108,7 @@ To clone into a specific temporary directory instead of using an automatically c
 To install into a repository-local skills directory instead of `~/.agents\skills`, run:
 
 ```powershell
-.\scripts\install.ps1 -DestSkillsDir C:\path\to\repo\.agents\skills
+.\scripts\install.ps1 -DestDir C:\path\to\repo
 ```
 
 Both installers clone this repository, copy each skill directory from `.agents/skills/` into the destination skills directory, and prompt before overwriting an existing skill with the same name. If you decline the prompt, that skill is skipped and the installer continues.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,21 +1,22 @@
 param(
   [string]$CloneDir,
+  [string]$DestSkillsDir,
   [switch]$Help
 )
 
 $ErrorActionPreference = "Stop"
 
 $RepoUrl = "https://github.com/warpdotdev/common-skills/"
-$DestSkillsDir = Join-Path $HOME ".agents\skills"
 $CleanupCloneDir = $false
 
 function Show-Usage {
-  Write-Output "Usage: ./install.ps1 [-CloneDir DIR]"
+  Write-Output "Usage: ./install.ps1 [-CloneDir DIR] [-DestSkillsDir DIR]"
   Write-Output ""
   Write-Output "Clone common-skills and copy its skills into $DestSkillsDir."
   Write-Output ""
   Write-Output "Options:"
   Write-Output "  -CloneDir DIR   Directory to clone common-skills into."
+  Write-Output "  -DestSkillsDir DIR   Directory to install skills into."
   Write-Output "  -Help           Show this help message."
 }
 
@@ -40,8 +41,14 @@ function Should-OverwriteSkill {
 }
 
 if ($Help) {
+  if ([string]::IsNullOrWhiteSpace($DestSkillsDir)) {
+    $DestSkillsDir = Join-Path $HOME ".agents\skills"
+  }
   Show-Usage
   exit 0
+}
+if ([string]::IsNullOrWhiteSpace($DestSkillsDir)) {
+  $DestSkillsDir = Join-Path $HOME ".agents\skills"
 }
 
 if ([string]::IsNullOrWhiteSpace($CloneDir)) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,6 +1,6 @@
 param(
   [string]$CloneDir,
-  [string]$DestSkillsDir,
+  [string]$DestDir,
   [switch]$Help
 )
 
@@ -10,13 +10,13 @@ $RepoUrl = "https://github.com/warpdotdev/common-skills/"
 $CleanupCloneDir = $false
 
 function Show-Usage {
-  Write-Output "Usage: ./install.ps1 [-CloneDir DIR] [-DestSkillsDir DIR]"
+  Write-Output "Usage: ./install.ps1 [-CloneDir DIR] [-DestDir DIR]"
   Write-Output ""
   Write-Output "Clone common-skills and copy its skills into $DestSkillsDir."
   Write-Output ""
   Write-Output "Options:"
   Write-Output "  -CloneDir DIR   Directory to clone common-skills into."
-  Write-Output "  -DestSkillsDir DIR   Directory to install skills into."
+  Write-Output "  -DestDir DIR    Base directory whose .agents\skills directory should receive skills."
   Write-Output "  -Help           Show this help message."
 }
 
@@ -41,14 +41,18 @@ function Should-OverwriteSkill {
 }
 
 if ($Help) {
-  if ([string]::IsNullOrWhiteSpace($DestSkillsDir)) {
+  if ([string]::IsNullOrWhiteSpace($DestDir)) {
     $DestSkillsDir = Join-Path $HOME ".agents\skills"
+  } else {
+    $DestSkillsDir = Join-Path $DestDir ".agents\skills"
   }
   Show-Usage
   exit 0
 }
-if ([string]::IsNullOrWhiteSpace($DestSkillsDir)) {
+if ([string]::IsNullOrWhiteSpace($DestDir)) {
   $DestSkillsDir = Join-Path $HOME ".agents\skills"
+} else {
+  $DestSkillsDir = Join-Path $DestDir ".agents\skills"
 }
 
 if ([string]::IsNullOrWhiteSpace($CloneDir)) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,7 +15,7 @@ Clone common-skills and copy its skills into ${DEST_SKILLS_DIR}.
 
 Options:
   -d, --clone-dir DIR   Directory to clone common-skills into.
-      --dest-dir DIR    Directory to install skills into.
+      --dest-dir DIR    Base directory whose .agents/skills directory should receive skills.
   -h, --help            Show this help message.
 EOF
 }
@@ -32,10 +32,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --dest-dir)
       if [[ $# -lt 2 || -z "$2" ]]; then
-        echo "error: --dest-dir requires a directory" >&2
+        echo "error: --dest-dir requires a base directory" >&2
         exit 1
       fi
-      DEST_SKILLS_DIR="$2"
+      DEST_SKILLS_DIR="$2/.agents/skills"
       shift 2
       ;;
     -h|--help)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,12 +9,13 @@ CLEANUP_CLONE_DIR=0
 
 usage() {
   cat <<EOF
-Usage: ./install.sh [--clone-dir DIR]
+Usage: ./install.sh [--clone-dir DIR] [--dest-dir DIR]
 
 Clone common-skills and copy its skills into ${DEST_SKILLS_DIR}.
 
 Options:
   -d, --clone-dir DIR   Directory to clone common-skills into.
+      --dest-dir DIR    Directory to install skills into.
   -h, --help            Show this help message.
 EOF
 }
@@ -27,6 +28,14 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       CLONE_DIR="$2"
+      shift 2
+      ;;
+    --dest-dir)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "error: --dest-dir requires a directory" >&2
+        exit 1
+      fi
+      DEST_SKILLS_DIR="$2"
       shift 2
       ;;
     -h|--help)


### PR DESCRIPTION
## Summary
- Add installer support for installing shared skills into a repository-local `.agents/skills` directory
- Have Bash `--dest-dir` and PowerShell `-DestDir` accept the repository/base directory and derive `.agents/skills` internally
- Document repository-local install usage, including piped installer arguments

## Validation
- `bash -n scripts/install.sh`
- `./scripts/install.sh --help`
- `pwsh -NoProfile -File scripts/install.ps1 -Help`
- `git --no-pager diff --check`

Conversation: https://staging.warp.dev/conversation/fca6b077-2c77-4050-bed6-a3b647fcf72a

Co-Authored-By: Oz <oz-agent@warp.dev>
