### PR TITLE
Add Brandalf skill

### DIFF
--- a/.agents/skills/brandalf/SKILL.md
+++ b/.agents/skills/brandalf/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: brandalf
+description: Guides creation, revision, and review of Warp- or Oz-branded assets. Use when working on launch pages, docs, HTML/CSS components, UI mockups, prompts, social assets, copy, presentations, or any other branded deliverable that should look and sound unmistakably Warp or Oz.
+---
+
+# Brandalf
+
+Use this skill as the entrypoint for Warp and Oz branding work.
+
+## Source of truth
+
+The canonical brand skill lives at:
+
+`https://warp-brand-site.vercel.app/brand/skill`
+
+Before creating or revising any Warp- or Oz-branded asset, read that URL and use its contents as the source of truth for:
+
+- visual style
+- color usage
+- typography
+- voice and tone
+- component rules
+- naming and capitalization
+- implementation guidance
+
+Do not rely on memory when the hosted skill can be fetched.
+
+## Workflow
+
+1. Fetch the hosted brand skill from `https://warp-brand-site.vercel.app/brand/skill`.
+2. Extract the guidance relevant to the asset being created.
+3. Apply those rules to the requested output.
+4. When presenting the result, briefly note any important brand constraints that materially shaped the output.
+
+## Scope
+
+Use Brandalf for assets related to:
+
+- Warp
+- Oz
+- Warp Drive
+- agentic development / ADE materials that are explicitly branded for Warp or Oz
+
+## If the source is unavailable
+
+If the hosted skill cannot be fetched, say that the canonical branding source was unavailable and ask the user whether to proceed with best-effort branding guidance or to retry fetching it.


### PR DESCRIPTION
## Description

Adds the Brandalf skill to this repo as a repo-local skill under `.agents/skills/brandalf/`.

The skill points agents to the canonical hosted Warp/Oz brand guidance before creating or revising branded assets, and preserves the Brandalf workflow and scope while using repo-conformant kebab-case skill metadata.

## Validation

- Validated required `SKILL.md` frontmatter and kebab-case skill name with a small Python check.
- Reviewed the git diff/status for the added skill file.

## Agent artifacts

- Conversation: https://staging.warp.dev/conversation/5202653f-e1cc-48ad-a806-1c4e998590a1

Co-Authored-By: Oz <oz-agent@warp.dev>
