### PR TITLE
Add common skills script resolver

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,6 +27,22 @@ scripts/remove_common_skills --project
 ```
 ## Invoking from client repositories
 Client repositories do not need to vendor these scripts. They should keep a small `script/resolve_common_skills` shim that loads this repository's `scripts/resolve_common_skills` and forwards arguments to it.
+For example, a client repo's `script/resolve_common_skills` shim can look like this:
+```sh
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+COMMON_SKILLS_REPO="warpdotdev/common-skills"
+COMMON_SKILLS_REF="${WARP_COMMON_SKILLS_REF:-main}"
+RAW_BASE_URL="${WARP_COMMON_SKILLS_RAW_BASE_URL:-https://raw.githubusercontent.com/${COMMON_SKILLS_REPO}/${COMMON_SKILLS_REF}/scripts}"
+
+if [[ -n "${WARP_COMMON_SKILLS_SCRIPTS_DIR:-}" ]]; then
+  exec "${WARP_COMMON_SKILLS_SCRIPTS_DIR%/}/resolve_common_skills" "$@"
+fi
+
+curl -fsSL "${RAW_BASE_URL%/}/resolve_common_skills" | bash -s -- "$@"
+```
 The shim's default path executes this repository's shared resolver through `curl`:
 ```sh
 curl -fsSL "https://raw.githubusercontent.com/warpdotdev/common-skills/${WARP_COMMON_SKILLS_REF:-main}/scripts/resolve_common_skills" | bash -s -- install_common_skills -- --repo-root "${REPO_ROOT}" --if-needed --prompt-for-target

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,7 @@
 # Common skills scripts
 These scripts help consuming repositories install, remove, and verify shared agent skills from `warpdotdev/common-skills`.
 ## Files
+- `resolve_common_skills`: resolves and executes scripts from this directory, a local override directory, or raw GitHub.
 - `install_common_skills`: installs or updates common skills, then verifies the installed contents.
 - `remove_common_skills`: removes installed common skills from a selected target.
 ## Quick start
@@ -25,12 +26,12 @@ Remove installed common skills:
 scripts/remove_common_skills --project
 ```
 ## Invoking from client repositories
-Client repositories do not need to vendor these scripts. `warpdotdev/warp#10617` adds a small `script/resolve_common_skills` wrapper to the Warp repo that resolves a script from this repository and forwards arguments to it.
-The wrapper's default path executes the raw GitHub script through `curl`:
+Client repositories do not need to vendor these scripts. They should keep a small `script/resolve_common_skills` shim that loads this repository's `scripts/resolve_common_skills` and forwards arguments to it.
+The shim's default path executes this repository's shared resolver through `curl`:
 ```sh
-curl -fsSL "https://raw.githubusercontent.com/warpdotdev/common-skills/${WARP_COMMON_SKILLS_REF:-main}/scripts/install_common_skills" | bash -s -- --repo-root "${REPO_ROOT}" --if-needed --prompt-for-target
+curl -fsSL "https://raw.githubusercontent.com/warpdotdev/common-skills/${WARP_COMMON_SKILLS_REF:-main}/scripts/resolve_common_skills" | bash -s -- install_common_skills -- --repo-root "${REPO_ROOT}" --if-needed --prompt-for-target
 ```
-Warp's bootstrap and run scripts call the wrapper instead of calling `curl` directly:
+Consumer bootstrap and run scripts call the shim instead of calling `curl` directly:
 ```sh
 ./script/resolve_common_skills install_common_skills -- --repo-root "${REPO_ROOT}" --if-needed --prompt-for-target
 ```

--- a/scripts/resolve_common_skills
+++ b/scripts/resolve_common_skills
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+COMMON_SKILLS_REPO="warpdotdev/common-skills"
+COMMON_SKILLS_REF="${WARP_COMMON_SKILLS_REF:-main}"
+RAW_BASE_URL="${WARP_COMMON_SKILLS_RAW_BASE_URL:-https://raw.githubusercontent.com/${COMMON_SKILLS_REPO}/${COMMON_SKILLS_REF}/scripts}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME=""
+
+usage() {
+  cat <<EOF
+Usage: scripts/resolve_common_skills <script-name> [-- <script-args...>]
+
+Execute a script from warpdotdev/common-skills/scripts.
+
+Resolution order:
+  1. WARP_COMMON_SKILLS_SCRIPTS_DIR
+  2. The sibling scripts directory from this checkout
+  3. The raw script from ${COMMON_SKILLS_REPO}
+
+Environment:
+  WARP_COMMON_SKILLS_SCRIPTS_DIR=/path/to/common-skills/scripts
+      Override where common-skills management scripts are loaded from.
+  WARP_COMMON_SKILLS_REF=<git-ref>
+      Override the remote common-skills ref used for the raw script.
+  WARP_COMMON_SKILLS_RAW_BASE_URL=https://...
+      Override the remote base URL used for raw script fallback.
+EOF
+}
+
+execute_from_dir() {
+  local scripts_dir="$1"
+  local script_path="${scripts_dir%/}/${SCRIPT_NAME}"
+  shift
+
+  if [[ -x "${script_path}" ]]; then
+    exec "${script_path}" "$@"
+  fi
+
+  if [[ -f "${script_path}" ]]; then
+    exec bash "${script_path}" "$@"
+  fi
+
+  return 1
+}
+
+execute_from_remote() {
+  local raw_url="${RAW_BASE_URL%/}/${SCRIPT_NAME}"
+  local temp_script=""
+  local status=0
+
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "error: curl is required to fetch ${raw_url}" >&2
+    return 1
+  fi
+
+  temp_script="$(mktemp "${TMPDIR:-/tmp}/common-skills-script.XXXXXX")"
+  if curl -fsSL "${raw_url}" -o "${temp_script}"; then
+    :
+  else
+    status=$?
+    rm -f "${temp_script}"
+    return "${status}"
+  fi
+
+  if bash "${temp_script}" "$@"; then
+    status=0
+  else
+    status=$?
+  fi
+  rm -f "${temp_script}"
+  return "${status}"
+}
+
+if [[ $# -lt 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+case "$1" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  */*|.|..|"")
+    echo "error: invalid common-skills script name: $1" >&2
+    usage >&2
+    exit 1
+    ;;
+  *)
+    SCRIPT_NAME="$1"
+    case "${SCRIPT_NAME}" in
+      *[!A-Za-z0-9_-]*)
+        echo "error: invalid common-skills script name: ${SCRIPT_NAME}" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+    shift
+    ;;
+esac
+if [[ "${1:-}" = "--" ]]; then
+  shift
+fi
+
+if [[ -n "${WARP_COMMON_SKILLS_SCRIPTS_DIR:-}" ]]; then
+  if execute_from_dir "${WARP_COMMON_SKILLS_SCRIPTS_DIR}" "$@"; then
+    exit 0
+  fi
+
+  echo "error: could not execute ${SCRIPT_NAME} from WARP_COMMON_SKILLS_SCRIPTS_DIR=${WARP_COMMON_SKILLS_SCRIPTS_DIR}" >&2
+  exit 1
+fi
+
+if execute_from_dir "${SCRIPT_DIR}" "$@"; then
+  exit 0
+fi
+
+execute_from_remote "$@"


### PR DESCRIPTION
## Summary
- Add a shared `scripts/resolve_common_skills` resolver that dispatches to local overrides, sibling scripts, or raw GitHub fallback.
- Update script README guidance so consuming repos call the shared resolver instead of fetching individual scripts directly.

This is in preparation for having more repos load common skills.

## Testing
- `bash -n scripts/resolve_common_skills`

Co-Authored-By: Oz <oz-agent@warp.dev>