### PR TITLE
Update install common skills flow

### DIFF
--- a/scripts/install_common_skills
+++ b/scripts/install_common_skills
@@ -720,10 +720,14 @@ function collectFiles(baseDir, currentDir, results) {
 }
 
 function normalizeCrlf(content) {
+  // Git or platform tooling may rewrite checked-out text files as CRLF even
+  // though the lockfile hash was computed from LF-normalized repository data.
+  const carriageReturnByte = 13;
+  const lineFeedByte = 10;
   const normalized = [];
   for (let index = 0; index < content.length; index++) {
     const byte = content[index];
-    if (byte === 13 && content[index + 1] === 10) {
+    if (byte === carriageReturnByte && content[index + 1] === lineFeedByte) {
       continue;
     }
     normalized.push(byte);
@@ -758,6 +762,8 @@ function verifyTarget(skills, installTarget) {
     }
 
     const computedHash = computeSkillFolderHash(skillDir);
+    // Preserve exact-byte verification first, then allow an equivalent CRLF
+    // checkout to match the lockfile before reporting drift.
     const normalizedComputedHash =
       computedHash === skill.computedHash ? computedHash : computeSkillFolderHash(skillDir, true);
     if (normalizedComputedHash !== skill.computedHash) {

--- a/scripts/install_common_skills
+++ b/scripts/install_common_skills
@@ -635,7 +635,10 @@ fail_if_global_lock_mismatch() {
 
   echo "error: global common skills are pinned to a different skills-lock.json than ${LOCK_FILE}." >&2
   echo "Another checkout may depend on the currently installed global common-skills version." >&2
-  echo "Explicitly reconcile the checkouts, update them to the same lock, or remove and reinstall the global common skills with scripts/remove_common_skills --repo-root ${REPO_ROOT} --global." >&2
+  echo "To reuse the installed global copy, update this checkout to the same skills-lock.json and rerun." >&2
+  echo "To keep this checkout's existing lock, rerun and choose project instead of global." >&2
+  echo "To replace the global copy, run this from the consuming repo and then rerun:" >&2
+  echo "  ./script/resolve_common_skills remove_common_skills -- --repo-root ${REPO_ROOT} --global" >&2
   exit 1
 }
 

--- a/scripts/install_common_skills
+++ b/scripts/install_common_skills
@@ -719,7 +719,19 @@ function collectFiles(baseDir, currentDir, results) {
   }
 }
 
-function computeSkillFolderHash(skillDir) {
+function normalizeCrlf(content) {
+  const normalized = [];
+  for (let index = 0; index < content.length; index++) {
+    const byte = content[index];
+    if (byte === 13 && content[index + 1] === 10) {
+      continue;
+    }
+    normalized.push(byte);
+  }
+  return Buffer.from(normalized);
+}
+
+function computeSkillFolderHash(skillDir, normalizeLineEndings = false) {
   const files = [];
   collectFiles(skillDir, skillDir, files);
   files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
@@ -727,7 +739,7 @@ function computeSkillFolderHash(skillDir) {
   const hash = crypto.createHash("sha256");
   for (const file of files) {
     hash.update(file.relativePath);
-    hash.update(file.content);
+    hash.update(normalizeLineEndings ? normalizeCrlf(file.content) : file.content);
   }
 
   return hash.digest("hex");
@@ -746,7 +758,9 @@ function verifyTarget(skills, installTarget) {
     }
 
     const computedHash = computeSkillFolderHash(skillDir);
-    if (computedHash !== skill.computedHash) {
+    const normalizedComputedHash =
+      computedHash === skill.computedHash ? computedHash : computeSkillFolderHash(skillDir, true);
+    if (normalizedComputedHash !== skill.computedHash) {
       errors.push(`error: ${name} does not match skills-lock.json`);
       errors.push(`  expected: ${skill.computedHash}`);
       errors.push(`  actual:   ${computedHash}`);


### PR DESCRIPTION
## Summary
- normalize CRLF differences when verifying installed skill hashes
- preserve the existing raw hash fast path when no normalization is needed

## Why this uses the lockfile/content hash instead of a Git hash
The installer creates and restores common skills through the `npx skills` flow, and consuming repos treat `skills-lock.json` as the source of truth for the installed artifact set. Verification therefore needs to compare the materialized skill directories against the lockfile's recorded content hash.

A Git hash would describe repository objects or revisions, but not the exact on-disk skill folders produced by `npx skills@1.5.6 experimental_install` or the copied global-install path. Using the lockfile/content hash keeps verification aligned with what the installer actually writes and lets us tolerate CRLF-only checkout differences without weakening drift detection.

## Reviewer Windows test
To validate the CRLF case on Windows:
1. Check out this branch in a Windows clone where Git is configured to materialize text files with CRLF line endings, for example with `git config core.autocrlf true` before checkout.
2. From a repo that already has a `skills-lock.json`, install the locked common skills with the usual flow, or reuse an existing project/global install created by `scripts/install_common_skills`.
3. Run `scripts/install_common_skills --verify-only --repo-root <repo-root> --project` or `--global`, matching the target you installed.
4. Confirm verification succeeds instead of reporting `does not match skills-lock.json` solely because the checked-out skill files use CRLF line endings.

## Validation
- `bash -n scripts/install_common_skills`

Co-Authored-By: Oz <oz-agent@warp.dev>
