### PR TITLE
fix: refine review-pr skill with evidence-backed rules from reviewer feedback

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -26,6 +26,9 @@ Review the current pull request and write the output to `review.json`.
 - If a concern involves untouched code, mention it in top-level `body` instead of an inline comment.
 - Do not suggest adding test cases that only vary constructor inputs or struct fields when the existing test already covers the meaningful behavior. Only suggest new tests when they exercise a distinct code path or edge case.
 - When a PR is clearly a V0 or initial implementation, frame robustness suggestions (timeouts, retries, lifecycle management) as optional future work rather than blocking concerns, unless they risk correctness, security, or data loss.
+- Before claiming that a symbol, function, or pattern is missing or does not exist, verify against the full file and surrounding code — not just the lines in the diff.
+- When reviewing optimization or heuristic code (caches, early exits, approximate checks), calibrate severity to the tolerance of the use case. Do not treat an imperfect optimization as a correctness bug.
+- Do not suggest switching to fields, APIs, or resources that may depend on external infrastructure (e.g. Terraform, cloud-provisioned schemas) without confirming they are available in the current environment.
 
 ## Repository-specific guidance
 


### PR DESCRIPTION
## Summary

Adds three new rules to the `review-pr` skill's Review Scope section, each backed by evidence from human reviewer feedback on warpdotdev/warp-server PRs in the week of 2026-05-29 to 2026-06-05.

### New rules

1. **Verify symbols in full file context** — Before claiming a symbol/function/pattern is missing, check the full file, not just the diff. (Evidence: PR #11601 — reviewer corrected bot for claiming a symbol didn't exist when it was in the same file.)

2. **Calibrate severity for optimization code** — When reviewing optimization or heuristic code (caches, early exits, approximate checks), calibrate severity to the tolerance of the use case. Don't treat imperfect optimizations as correctness bugs. (Evidence: PR #11624 — reviewer noted the bot missed the nuance that the check was "just an optimization" and didn't need to be perfect.)

3. **Don't suggest infrastructure-dependent resources** — Don't suggest switching to fields/APIs/resources that depend on external infrastructure (e.g. Terraform) without confirming they're available. (Evidence: PR #11668 — reviewer corrected bot for suggesting a field not yet provisioned via Terraform.)

### What was not changed

- **review-spec skill**: Only one spec PR (#11665) had human comments this week, and they were clarifying Q&A between the spec author and reviewers — no actionable signal for skill changes.
- No feedback_items (direct replies to bot review comments) were found this week, but several human review comment threads included substantive corrections to bot behavior.

cc @captainsafia

_Conversation: https://staging.warp.dev/conversation/6f40db5f-b328-4025-8449-6460076103c3_
_Run: https://oz.staging.warp.dev/runs/019e984c-681e-72bd-9693-f349a3ad1438_

_This PR was generated with [Oz](https://warp.dev/oz)._

Co-Authored-By: Oz <oz-agent@warp.dev>
