### PR TITLE
Add write-feature-docs skill

### DIFF
--- a/.agents/skills/scan-new-specs/SKILL.md
+++ b/.agents/skills/scan-new-specs/SKILL.md
@@ -178,6 +178,14 @@ Suggested schedule: every Monday, Wednesday, and Friday at 9am PT — frequent e
 
 This skill does not maintain persistent state between runs. Deduplication relies entirely on whether a docs PR exists in `warpdotdev/docs` — if a PR is open or merged for a spec, it won't be flagged again. This means a spec will continue to generate nudges until someone opens a docs PR for it (even a draft).
 
+**Edge case:** if a docs draft PR was opened and then *closed* (not merged), the spec will be re-flagged on the next run since closed PRs are not counted as coverage. This is intentional — a closed PR means docs work was abandoned and needs re-triggering.
+
+## Slack @mention note
+
+Incoming webhooks post plain text only. The `@<ENG_NAME>` mention in the Slack message is a plain text name, not a real Slack user ping — the engineer won't receive a notification directly. The message will be visible in `#growth-docs` and the docs team can follow up.
+
+To enable real user pings, a Slack app with `chat:write` and `users:read.email` scopes would be needed to look up Slack user IDs from GitHub email addresses. This is a future enhancement.
+
 ## Related skills
 
 - `write-feature-docs` — the skill engineers run to generate the docs draft after being nudged

--- a/.agents/skills/scan-new-specs/SKILL.md
+++ b/.agents/skills/scan-new-specs/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: scan-new-specs
-description: Scan warp-internal and warp-server for recently merged PRODUCT.md specs that don't yet have a corresponding docs PR in warpdotdev/docs, then post Slack nudges to a configured channel. Designed to run as a scheduled Oz ambient agent (e.g., every 2-3 days). Use when setting up the automated docs trigger, running a manual docs coverage sweep, or checking whether any new specs are missing documentation.
+description: Scan warpdotdev/warp and warp-server for recently merged PRODUCT.md specs that don't yet have a corresponding docs PR in warpdotdev/docs, then post Slack nudges to a configured channel. Designed to run as a scheduled Oz ambient agent (e.g., every 2-3 days). Use when setting up the automated docs trigger, running a manual docs coverage sweep, or checking whether any new specs are missing documentation.
 ---
 
 # scan-new-specs
 
-Scan `warp-internal` and `warp-server` for recently merged product or tech specs that lack a corresponding docs draft, and post a Slack nudge to `#growth-docs` for each gap. This is the automated companion to the `write-feature-docs` skill — it surfaces docs gaps so the docs team can follow up with the engineer, without requiring engineers to remember to kick off the docs-drafting workflow themselves.
+Scan `warpdotdev/warp` and `warp-server` for recently merged product or tech specs that lack a corresponding docs draft, and post a Slack nudge to `#growth-docs` for each gap. This is the automated companion to the `write-feature-docs` skill — it surfaces docs gaps so the docs team can follow up with the engineer, without requiring engineers to remember to kick off the docs-drafting workflow themselves.
 
 ## Configuration
 
@@ -24,9 +24,9 @@ If `SLACK_WEBHOOK_URL` is not set in the environment, print the nudge messages t
 Use the GitHub CLI to search both repos for PRs merged in the last `LOOKBACK_DAYS` days that added a new `PRODUCT.md` file under `specs/`:
 
 ```bash
-# Find merged PRs in warp-internal that added a PRODUCT.md
+# Find merged PRs in warpdotdev/warp (OSS repo) that added a PRODUCT.md
 gh pr list \
-  --repo warpdotdev/warp-internal \
+  --repo warpdotdev/warp \
   --state merged \
   --search "merged:>$(date -v-${LOOKBACK_DAYS}d +%Y-%m-%d) specs PRODUCT.md in:files" \
   --json number,title,author,mergedAt,url \
@@ -48,7 +48,7 @@ gh pr view <number> --repo warpdotdev/<repo> --json files -q '.files[].path' \
   | grep -E '^specs/.+/PRODUCT\.md$'
 ```
 
-Collect the list of: spec ID (the directory name under `specs/`), spec PR number and URL, PR author GitHub username, repo (`warp-internal` or `warp-server`), and merge date.
+Collect the list of: spec ID (the directory name under `specs/`), spec PR number and URL, PR author GitHub username, repo (`warp` or `warp-server`), and merge date.
 
 ## Step 2: Check for existing docs coverage
 
@@ -113,7 +113,7 @@ Always print a run summary to stdout:
 
 ```
 scan-new-specs run summary
-  Repos scanned:        warp-internal, warp-server
+  Repos scanned:        warpdotdev/warp, warp-server
   Lookback window:      <N> days (since <date>)
   Specs found:          <N>
   Already covered:      <N>
@@ -125,7 +125,7 @@ scan-new-specs run summary
 
 This skill is designed to run as a **scheduled Oz ambient agent** every 2–3 days. A suggested prompt for the Oz agent configuration:
 
-> "Run scan-new-specs to check warp-internal and warp-server for newly merged PRODUCT.md specs that don't have a corresponding docs PR in warpdotdev/docs. Post nudges to #growth-docs for any gaps. Use the last 3 days as the lookback window."
+> "Run scan-new-specs to check warpdotdev/warp and warp-server for newly merged PRODUCT.md specs that don't have a corresponding docs PR in warpdotdev/docs. Post nudges to #growth-docs for any gaps. Use the last 3 days as the lookback window."
 
 Suggested schedule: every Monday, Wednesday, and Friday at 9am PT — frequent enough to catch specs quickly, but not noisy.
 

--- a/.agents/skills/scan-new-specs/SKILL.md
+++ b/.agents/skills/scan-new-specs/SKILL.md
@@ -22,9 +22,11 @@ Before running, confirm these values (or accept the defaults):
 |---|---|---|
 | `LOOKBACK_DAYS` | `3` | How many days back to scan for merged spec PRs |
 | `SLACK_CHANNEL` | `#growth-docs` | Slack channel for engineer pings and summaries (temporary — see TODO above) |
-| `SLACK_WEBHOOK_URL` | Required | Slack incoming webhook URL (store as a secret) |
+| `SLACK_BOT_TOKEN` | From `buzz` environment | Slack bot token for posting via API (already available in the `buzz` Oz environment) |
 
-If `SLACK_WEBHOOK_URL` is not set, print all messages to stdout instead.
+This skill uses the Slack API (`chat.postMessage`) rather than an incoming webhook, which enables real user pings. The `buzz` Oz environment already has the required `SLACK_BOT_TOKEN`. No new secrets setup is needed.
+
+If `SLACK_BOT_TOKEN` is not set, print all messages to stdout instead.
 
 ## Step 1: Find recently merged specs
 
@@ -57,17 +59,29 @@ gh pr view <number> --repo warpdotdev/<repo> --json files -q '.files[].path' \
 
 Collect the list of: spec ID (the directory name under `specs/`), spec PR number and URL, PR author GitHub username, repo (`warp` or `warp-server`), and merge date.
 
-For each PR author's GitHub username, also resolve their likely Slack handle:
+For each PR author's GitHub username, resolve their Slack identity:
 
 ```bash
-# Get the engineer's display name from GitHub
+# Get the engineer's name and email from GitHub
 ENG_NAME=$(gh api users/<github-username> -q '.name // .login')
-# Use the full name for the Slack @mention (e.g. "Harry Albert" → @Harry Albert)
-# Most Warp engineers use first+last name as their Slack handle
-# Flag the mention as unverified in the message so readers can correct it if wrong
+ENG_EMAIL=$(gh api users/<github-username> -q '.email // empty')
+
+# Look up their Slack user ID by email (real ping, not just a name mention)
+if [ -n "$ENG_EMAIL" ]; then
+  SLACK_USER_ID=$(curl -s -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+    "https://slack.com/api/users.lookupByEmail?email=${ENG_EMAIL}" \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['user']['id'] if d.get('ok') else '')")
+fi
+
+# Use <@USER_ID> for a real ping if lookup succeeded; fall back to @name if not
+if [ -n "$SLACK_USER_ID" ]; then
+  ENG_MENTION="<@${SLACK_USER_ID}>"
+else
+  ENG_MENTION="@${ENG_NAME} _(Slack ID not found — verify this is the right person)_"
+fi
 ```
 
-Store `ENG_NAME` and `ENG_GITHUB` (the GitHub username) for use in Slack messages.
+Store `ENG_MENTION`, `ENG_NAME`, and `ENG_GITHUB` for use in Slack messages.
 
 ## Step 2: Check for existing docs coverage
 
@@ -111,9 +125,9 @@ For each uncovered spec, read `specs/<id>/PRODUCT.md` and assess whether it has 
 
 Feature: *<spec-id>* (from `<repo>`)
 Spec PR: <spec-pr-url>
-@<ENG_NAME> _(GitHub: <github-username> — verify this Slack handle is correct)_
+<@USER_ID> (GitHub: <github-username>)
 
-I've opened a draft docs PR for review: <docs-pr-url>
+I’ve opened a draft docs PR for review: <docs-pr-url>
 Please check the items marked *[UNVERIFIED]* and *[TODO]* in the PR — those are the only things that need your input.
 ```
 
@@ -126,11 +140,11 @@ Post this Slack message to `SLACK_CHANNEL`:
 
 Feature: *<spec-id>* (from `<repo>`)
 Spec PR: <spec-pr-url>
-@<ENG_NAME> _(GitHub: <github-username> — verify this Slack handle is correct)_
+<@USER_ID> (GitHub: <github-username>)
 
-The spec doesn't have enough behavior detail for me to auto-generate docs yet. Please either:
+The spec doesn’t have enough behavior detail for me to auto-generate docs yet. Please either:
 • Add more detail to `specs/<spec-id>/PRODUCT.md` (a Behavior section with user-facing steps), OR
-• Ping the docs team in this channel and we'll draft it manually
+• Ping the docs team in this channel and we’ll draft it manually
 ```
 
 If there are no uncovered specs, post:
@@ -141,15 +155,16 @@ If there are no uncovered specs, post:
 
 ## Step 5: Post to Slack
 
-Send each message to `SLACK_CHANNEL` via the incoming webhook:
+Post each message using the Slack API:
 
 ```bash
-curl -s -X POST "$SLACK_WEBHOOK_URL" \
+curl -s -X POST https://slack.com/api/chat.postMessage \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
   -H 'Content-type: application/json' \
-  --data "{\"text\": \"$MESSAGE\"}"
+  --data "{\"channel\": \"$SLACK_CHANNEL\", \"text\": \"$MESSAGE\"}"
 ```
 
-If `SLACK_WEBHOOK_URL` is not set, print the message to stdout instead.
+If `SLACK_BOT_TOKEN` is not set, print the message to stdout instead.
 
 ## Step 6: Print a summary
 
@@ -180,11 +195,11 @@ This skill does not maintain persistent state between runs. Deduplication relies
 
 **Edge case:** if a docs draft PR was opened and then *closed* (not merged), the spec will be re-flagged on the next run since closed PRs are not counted as coverage. This is intentional — a closed PR means docs work was abandoned and needs re-triggering.
 
-## Slack @mention note
+## Slack mention note
 
-Incoming webhooks post plain text only. The `@<ENG_NAME>` mention in the Slack message is a plain text name, not a real Slack user ping — the engineer won't receive a notification directly. The message will be visible in `#growth-docs` and the docs team can follow up.
+This skill uses the Slack API (`chat.postMessage`) with the `SLACK_BOT_TOKEN` from the `buzz` Oz environment. This supports real `<@USER_ID>` mentions — engineers will receive a direct notification when their spec is detected.
 
-To enable real user pings, a Slack app with `chat:write` and `users:read.email` scopes would be needed to look up Slack user IDs from GitHub email addresses. This is a future enhancement.
+The user ID is resolved by looking up the engineer's GitHub email against the Slack `users.lookupByEmail` API. If the engineer has a private GitHub email, the lookup will fail and the message will fall back to a plain-text name with a note to verify manually.
 
 ## Related skills
 

--- a/.agents/skills/scan-new-specs/SKILL.md
+++ b/.agents/skills/scan-new-specs/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: scan-new-specs
+description: Scan warp-internal and warp-server for recently merged PRODUCT.md specs that don't yet have a corresponding docs PR in warpdotdev/docs, then post Slack nudges to a configured channel. Designed to run as a scheduled Oz ambient agent (e.g., every 2-3 days). Use when setting up the automated docs trigger, running a manual docs coverage sweep, or checking whether any new specs are missing documentation.
+---
+
+# scan-new-specs
+
+Scan `warp-internal` and `warp-server` for recently merged specs that lack a corresponding docs draft, and post a Slack nudge to `#growth-docs` for each gap. This is the automated companion to the `write-feature-docs` skill — it surfaces docs gaps so the docs team can follow up with the engineer, without requiring engineers to remember to kick off the docs-drafting workflow themselves.
+
+## Configuration
+
+Before running, confirm these values (or accept the defaults):
+
+| Setting | Default | Description |
+|---|---|---|
+| `LOOKBACK_DAYS` | `3` | How many days back to scan for merged spec PRs |
+| `SLACK_CHANNEL` | `#growth-docs` | Slack channel to post nudges to |
+| `SLACK_WEBHOOK_URL` | Required | Slack incoming webhook URL (should be stored as a secret) |
+
+If `SLACK_WEBHOOK_URL` is not set in the environment, print the nudge messages to stdout instead so the output can be reviewed manually.
+
+## Step 1: Find recently merged specs
+
+Use the GitHub CLI to search both repos for PRs merged in the last `LOOKBACK_DAYS` days that added a new `PRODUCT.md` file under `specs/`:
+
+```bash
+# Find merged PRs in warp-internal that added a PRODUCT.md
+gh pr list \
+  --repo warpdotdev/warp-internal \
+  --state merged \
+  --search "merged:>$(date -v-${LOOKBACK_DAYS}d +%Y-%m-%d) specs PRODUCT.md in:files" \
+  --json number,title,author,mergedAt,url \
+  --limit 50
+
+# Repeat for warp-server
+gh pr list \
+  --repo warpdotdev/warp-server \
+  --state merged \
+  --search "merged:>$(date -v-${LOOKBACK_DAYS}d +%Y-%m-%d) specs PRODUCT.md in:files" \
+  --json number,title,author,mergedAt,url \
+  --limit 50
+```
+
+For each PR returned, verify it actually contains a new `specs/*/PRODUCT.md` by inspecting the files changed:
+
+```bash
+gh pr view <number> --repo warpdotdev/<repo> --json files -q '.files[].path' \
+  | grep -E '^specs/.+/PRODUCT\.md$'
+```
+
+Collect the list of: spec ID (the directory name under `specs/`), spec PR number and URL, PR author GitHub username, repo (`warp-internal` or `warp-server`), and merge date.
+
+## Step 2: Check for existing docs coverage
+
+For each spec found, search `warpdotdev/docs` for an open or recently merged PR that mentions the spec ID or feature name:
+
+```bash
+gh pr list \
+  --repo warpdotdev/docs \
+  --state all \
+  --search "<spec-id>" \
+  --json number,title,state,url \
+  --limit 10
+```
+
+A spec is considered **covered** if any matching PR exists (open, merged, or draft). Skip covered specs — do not send a nudge.
+
+A spec is **uncovered** if no matching PR is found in `warpdotdev/docs`.
+
+## Step 3: Build the nudge messages
+
+For each uncovered spec, compose a Slack message. Keep it brief and actionable:
+
+```
+📄 *New spec merged, no docs yet*
+
+Feature: *<spec-id>* (from `<repo>`)
+Spec PR: <spec-pr-url>
+Merged by: @<github-username> on <merge-date>
+
+To create the docs draft, run `write-feature-docs` from `<repo>` with spec ID `<spec-id>`.
+```
+
+Group multiple nudges into a single Slack message when possible to avoid spamming the channel. Use a summary header if there are 3+ uncovered specs:
+
+```
+📄 *Docs coverage scan — <N> specs need docs*
+
+<list of nudge items>
+```
+
+If there are no uncovered specs, post a single brief message:
+
+```
+✅ *Docs coverage scan complete* — all recently merged specs have docs coverage.
+```
+
+## Step 4: Post to Slack
+
+Send the composed message to `SLACK_CHANNEL` via the incoming webhook:
+
+```bash
+curl -s -X POST "$SLACK_WEBHOOK_URL" \
+  -H 'Content-type: application/json' \
+  --data "{\"text\": \"$MESSAGE\"}"
+```
+
+If `SLACK_WEBHOOK_URL` is not set, print the message to stdout instead and note that no Slack notification was sent.
+
+## Step 5: Print a summary
+
+Always print a run summary to stdout:
+
+```
+scan-new-specs run summary
+  Repos scanned:        warp-internal, warp-server
+  Lookback window:      <N> days (since <date>)
+  Specs found:          <N>
+  Already covered:      <N>
+  Nudges sent:          <N>
+  Slack channel:        <channel>
+```
+
+## Scheduling
+
+This skill is designed to run as a **scheduled Oz ambient agent** every 2–3 days. A suggested prompt for the Oz agent configuration:
+
+> "Run scan-new-specs to check warp-internal and warp-server for newly merged PRODUCT.md specs that don't have a corresponding docs PR in warpdotdev/docs. Post nudges to #growth-docs for any gaps. Use the last 3 days as the lookback window."
+
+Suggested schedule: every Monday, Wednesday, and Friday at 9am PT — frequent enough to catch specs quickly, but not noisy.
+
+## Deduplication note
+
+This skill does not maintain persistent state between runs. Deduplication relies entirely on whether a docs PR exists in `warpdotdev/docs` — if a PR is open or merged for a spec, it won't be flagged again. This means a spec will continue to generate nudges until someone opens a docs PR for it (even a draft).
+
+## Related skills
+
+- `write-feature-docs` — the skill engineers run to generate the docs draft after being nudged

--- a/.agents/skills/scan-new-specs/SKILL.md
+++ b/.agents/skills/scan-new-specs/SKILL.md
@@ -30,27 +30,31 @@ If `SLACK_BOT_TOKEN` is not set, print all messages to stdout instead.
 
 ## Step 1: Find recently merged specs
 
-Use the GitHub CLI to search both repos for PRs merged in the last `LOOKBACK_DAYS` days that added a new `PRODUCT.md` file under `specs/`:
+List merged PRs from both repos since the lookback date, then filter by changed files. Do not use `--search "in:files"` (GitHub does not support file-path filtering in PR search) and use a portable date command that works on both Linux and macOS:
 
 ```bash
-# Find merged PRs in warpdotdev/warp (OSS repo) that added a PRODUCT.md
+# Portable date calculation (GNU/Linux and BSD/macOS compatible)
+SINCE=$(date -d "-${LOOKBACK_DAYS} days" +%Y-%m-%d 2>/dev/null \
+        || date -v-${LOOKBACK_DAYS}d +%Y-%m-%d)
+
+# List all recently merged PRs (no file-path filter -- we check files next)
 gh pr list \
   --repo warpdotdev/warp \
   --state merged \
-  --search "merged:>$(date -v-${LOOKBACK_DAYS}d +%Y-%m-%d) specs PRODUCT.md in:files" \
+  --search "merged:>${SINCE}" \
   --json number,title,author,mergedAt,url \
-  --limit 50
+  --limit 100
 
 # Repeat for warp-server
 gh pr list \
   --repo warpdotdev/warp-server \
   --state merged \
-  --search "merged:>$(date -v-${LOOKBACK_DAYS}d +%Y-%m-%d) specs PRODUCT.md in:files" \
+  --search "merged:>${SINCE}" \
   --json number,title,author,mergedAt,url \
-  --limit 50
+  --limit 100
 ```
 
-For each PR returned, verify it actually contains a new `specs/*/PRODUCT.md` by inspecting the files changed:
+For each PR returned, check whether it actually contains a new `specs/*/PRODUCT.md` by inspecting the changed files (this is the correct filter step):
 
 ```bash
 gh pr view <number> --repo warpdotdev/<repo> --json files -q '.files[].path' \
@@ -85,20 +89,29 @@ Store `ENG_MENTION`, `ENG_NAME`, and `ENG_GITHUB` for use in Slack messages.
 
 ## Step 2: Check for existing docs coverage
 
-For each spec found, search `warpdotdev/docs` for an open or recently merged PR that mentions the spec ID or feature name:
+For each spec found, check `warpdotdev/docs` for an open/draft or merged PR that mentions the spec ID. Run two separate queries to avoid counting closed-unmerged PRs as coverage:
 
 ```bash
+# Check for open or draft PRs
 gh pr list \
   --repo warpdotdev/docs \
-  --state all \
+  --state open \
   --search "<spec-id>" \
   --json number,title,state,url \
-  --limit 10
+  --limit 5
+
+# Check for merged PRs
+gh pr list \
+  --repo warpdotdev/docs \
+  --state merged \
+  --search "<spec-id>" \
+  --json number,title,state,url \
+  --limit 5
 ```
 
-A spec is considered **covered** if any matching PR exists (open, merged, or draft). Skip covered specs.
+A spec is considered **covered** if either query returns results (open, draft, or merged PR exists). Skip covered specs.
 
-A spec is **uncovered** if no matching PR is found in `warpdotdev/docs`.
+A spec is **uncovered** if neither query returns results. Closed-unmerged PRs do **not** count as coverage — a closed PR signals abandoned work that needs re-triggering.
 
 ## Step 3: Assess spec completeness
 
@@ -155,13 +168,17 @@ If there are no uncovered specs, post:
 
 ## Step 5: Post to Slack
 
-Post each message using the Slack API:
+Post each message using the Slack API. Build the JSON payload with `jq` to safely handle newlines, quotes, and backslashes in `$MESSAGE`:
 
 ```bash
-curl -s -X POST https://slack.com/api/chat.postMessage \
-  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-  -H 'Content-type: application/json' \
-  --data "{\"channel\": \"$SLACK_CHANNEL\", \"text\": \"$MESSAGE\"}"
+jq -n \
+  --arg channel "$SLACK_CHANNEL" \
+  --arg text "$MESSAGE" \
+  '{channel: $channel, text: $text}' \
+| curl -s -X POST https://slack.com/api/chat.postMessage \
+    -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+    -H 'Content-type: application/json' \
+    -d @-
 ```
 
 If `SLACK_BOT_TOKEN` is not set, print the message to stdout instead.

--- a/.agents/skills/scan-new-specs/SKILL.md
+++ b/.agents/skills/scan-new-specs/SKILL.md
@@ -1,11 +1,18 @@
 ---
 name: scan-new-specs
-description: Scan warpdotdev/warp and warp-server for recently merged PRODUCT.md specs that don't yet have a corresponding docs PR in warpdotdev/docs, then post Slack nudges to a configured channel. Designed to run as a scheduled Oz ambient agent (e.g., every 2-3 days). Use when setting up the automated docs trigger, running a manual docs coverage sweep, or checking whether any new specs are missing documentation.
+description: Scan warpdotdev/warp and warp-server for recently merged PRODUCT.md specs that don't yet have a corresponding docs PR in warpdotdev/docs. When a complete spec is found, auto-generates a full docs draft PR and tags the engineer. When a spec is too thin to draft from, pings the engineer directly. Designed to run as a scheduled Oz ambient agent (e.g., every 2-3 days). Use when setting up the automated docs trigger or running a manual docs coverage sweep.
 ---
 
 # scan-new-specs
 
-Scan `warpdotdev/warp` and `warp-server` for recently merged product or tech specs that lack a corresponding docs draft, and post a Slack nudge to `#growth-docs` for each gap. This is the automated companion to the `write-feature-docs` skill — it surfaces docs gaps so the docs team can follow up with the engineer, without requiring engineers to remember to kick off the docs-drafting workflow themselves.
+Scan `warpdotdev/warp` and `warp-server` for recently merged product or tech specs that lack a corresponding docs draft. For each gap:
+
+- **If the spec is complete** — automatically run `write-feature-docs` in ambient mode to generate a full draft PR in `warpdotdev/docs`, then ping the engineer to review it
+- **If the spec is thin** — ping the engineer directly to either flesh out the spec or kick off the docs workflow manually
+
+In both cases, post a summary to `#growth-docs`.
+
+> **TODO for reviewers:** `#growth-docs` is a temporary channel for engineer pings. Identify a more appropriate eng-facing channel (e.g. a shared eng/docs channel, `#dev`, or a dedicated `#docs-requests` channel) once this workflow is established.
 
 ## Configuration
 
@@ -14,10 +21,10 @@ Before running, confirm these values (or accept the defaults):
 | Setting | Default | Description |
 |---|---|---|
 | `LOOKBACK_DAYS` | `3` | How many days back to scan for merged spec PRs |
-| `SLACK_CHANNEL` | `#growth-docs` | Slack channel to post nudges to |
-| `SLACK_WEBHOOK_URL` | Required | Slack incoming webhook URL (should be stored as a secret) |
+| `SLACK_CHANNEL` | `#growth-docs` | Slack channel for engineer pings and summaries (temporary — see TODO above) |
+| `SLACK_WEBHOOK_URL` | Required | Slack incoming webhook URL (store as a secret) |
 
-If `SLACK_WEBHOOK_URL` is not set in the environment, print the nudge messages to stdout instead so the output can be reviewed manually.
+If `SLACK_WEBHOOK_URL` is not set, print all messages to stdout instead.
 
 ## Step 1: Find recently merged specs
 
@@ -50,6 +57,18 @@ gh pr view <number> --repo warpdotdev/<repo> --json files -q '.files[].path' \
 
 Collect the list of: spec ID (the directory name under `specs/`), spec PR number and URL, PR author GitHub username, repo (`warp` or `warp-server`), and merge date.
 
+For each PR author's GitHub username, also resolve their likely Slack handle:
+
+```bash
+# Get the engineer's display name from GitHub
+ENG_NAME=$(gh api users/<github-username> -q '.name // .login')
+# Use the full name for the Slack @mention (e.g. "Harry Albert" → @Harry Albert)
+# Most Warp engineers use first+last name as their Slack handle
+# Flag the mention as unverified in the message so readers can correct it if wrong
+```
+
+Store `ENG_NAME` and `ENG_GITHUB` (the GitHub username) for use in Slack messages.
+
 ## Step 2: Check for existing docs coverage
 
 For each spec found, search `warpdotdev/docs` for an open or recently merged PR that mentions the spec ID or feature name:
@@ -63,41 +82,66 @@ gh pr list \
   --limit 10
 ```
 
-A spec is considered **covered** if any matching PR exists (open, merged, or draft). Skip covered specs — do not send a nudge.
+A spec is considered **covered** if any matching PR exists (open, merged, or draft). Skip covered specs.
 
 A spec is **uncovered** if no matching PR is found in `warpdotdev/docs`.
 
-## Step 3: Build the nudge messages
+## Step 3: Assess spec completeness
 
-For each uncovered spec, compose a Slack message. Keep it brief and actionable:
+For each uncovered spec, read `specs/<id>/PRODUCT.md` and assess whether it has enough content to auto-draft from:
+
+**Complete** (proceed to auto-draft) if ALL of the following are true:
+- File is at least 40 lines long
+- Contains a `## Behavior` section (or equivalent) with numbered invariants or user-facing steps
+- Describes at least one concrete user action (not just a summary paragraph)
+
+**Thin** (ping engineer instead) if the spec is a stub — only a Summary section, fewer than 40 lines, or no behavior detail.
+
+## Step 4: Act based on spec completeness
+
+### Path A: Complete spec → auto-draft
+
+1. Run `write-feature-docs` in **ambient mode** (see `write-feature-docs` skill for details) — this skips the interactive outline confirmation and instead embeds the outline as a checklist in the PR description
+2. The PR is opened in `warpdotdev/docs` with the draft and a checklist of items needing engineer verification
+3. Request review from the engineer (`@<github-username>`) and from `@rachaelrenk`, `@petradonka`, and `@hongyi-chen`
+4. Post this Slack message to `SLACK_CHANNEL`:
 
 ```
-📄 *New spec merged, no docs yet*
+📄 *Docs draft auto-generated*
 
 Feature: *<spec-id>* (from `<repo>`)
 Spec PR: <spec-pr-url>
-Merged by: @<github-username> on <merge-date>
+@<ENG_NAME> _(GitHub: <github-username> — verify this Slack handle is correct)_
 
-To create the docs draft, run `write-feature-docs` from `<repo>` with spec ID `<spec-id>`.
+I've opened a draft docs PR for review: <docs-pr-url>
+Please check the items marked *[UNVERIFIED]* and *[TODO]* in the PR — those are the only things that need your input.
 ```
 
-Group multiple nudges into a single Slack message when possible to avoid spamming the channel. Use a summary header if there are 3+ uncovered specs:
+### Path B: Thin spec → ping engineer
+
+Post this Slack message to `SLACK_CHANNEL`:
 
 ```
-📄 *Docs coverage scan — <N> specs need docs*
+📋 *New spec needs docs — not enough detail to auto-draft*
 
-<list of nudge items>
+Feature: *<spec-id>* (from `<repo>`)
+Spec PR: <spec-pr-url>
+@<ENG_NAME> _(GitHub: <github-username> — verify this Slack handle is correct)_
+
+The spec doesn't have enough behavior detail for me to auto-generate docs yet. Please either:
+• Add more detail to `specs/<spec-id>/PRODUCT.md` (a Behavior section with user-facing steps), OR
+• Ping the docs team in this channel and we'll draft it manually
 ```
 
-If there are no uncovered specs, post a single brief message:
+If there are no uncovered specs, post:
 
 ```
 ✅ *Docs coverage scan complete* — all recently merged specs have docs coverage.
 ```
 
-## Step 4: Post to Slack
+## Step 5: Post to Slack
 
-Send the composed message to `SLACK_CHANNEL` via the incoming webhook:
+Send each message to `SLACK_CHANNEL` via the incoming webhook:
 
 ```bash
 curl -s -X POST "$SLACK_WEBHOOK_URL" \
@@ -105,27 +149,28 @@ curl -s -X POST "$SLACK_WEBHOOK_URL" \
   --data "{\"text\": \"$MESSAGE\"}"
 ```
 
-If `SLACK_WEBHOOK_URL` is not set, print the message to stdout instead and note that no Slack notification was sent.
+If `SLACK_WEBHOOK_URL` is not set, print the message to stdout instead.
 
-## Step 5: Print a summary
+## Step 6: Print a summary
 
 Always print a run summary to stdout:
 
 ```
 scan-new-specs run summary
-  Repos scanned:        warpdotdev/warp, warp-server
-  Lookback window:      <N> days (since <date>)
-  Specs found:          <N>
-  Already covered:      <N>
-  Nudges sent:          <N>
-  Slack channel:        <channel>
+  Repos scanned:         warpdotdev/warp, warp-server
+  Lookback window:       <N> days (since <date>)
+  Specs found:           <N>
+  Already covered:       <N>
+  Auto-drafted:          <N>   (complete spec → draft PR opened)
+  Pinged (thin spec):    <N>   (incomplete spec → engineer notified)
+  Slack channel:         <channel>
 ```
 
 ## Scheduling
 
 This skill is designed to run as a **scheduled Oz ambient agent** every 2–3 days. A suggested prompt for the Oz agent configuration:
 
-> "Run scan-new-specs to check warpdotdev/warp and warp-server for newly merged PRODUCT.md specs that don't have a corresponding docs PR in warpdotdev/docs. Post nudges to #growth-docs for any gaps. Use the last 3 days as the lookback window."
+> "Run scan-new-specs to check warpdotdev/warp and warp-server for newly merged PRODUCT.md specs that don't have a corresponding docs PR in warpdotdev/docs. For complete specs, auto-generate a draft docs PR and tag the engineer. For thin specs, ping the engineer in Slack. Post a summary to #growth-docs. Use the last 3 days as the lookback window."
 
 Suggested schedule: every Monday, Wednesday, and Friday at 9am PT — frequent enough to catch specs quickly, but not noisy.
 

--- a/.agents/skills/scan-new-specs/SKILL.md
+++ b/.agents/skills/scan-new-specs/SKILL.md
@@ -5,7 +5,7 @@ description: Scan warp-internal and warp-server for recently merged PRODUCT.md s
 
 # scan-new-specs
 
-Scan `warp-internal` and `warp-server` for recently merged specs that lack a corresponding docs draft, and post a Slack nudge to `#growth-docs` for each gap. This is the automated companion to the `write-feature-docs` skill — it surfaces docs gaps so the docs team can follow up with the engineer, without requiring engineers to remember to kick off the docs-drafting workflow themselves.
+Scan `warp-internal` and `warp-server` for recently merged product or tech specs that lack a corresponding docs draft, and post a Slack nudge to `#growth-docs` for each gap. This is the automated companion to the `write-feature-docs` skill — it surfaces docs gaps so the docs team can follow up with the engineer, without requiring engineers to remember to kick off the docs-drafting workflow themselves.
 
 ## Configuration
 

--- a/.agents/skills/write-feature-docs/SKILL.md
+++ b/.agents/skills/write-feature-docs/SKILL.md
@@ -192,11 +192,99 @@ These conventions come from the Warp docs style guide and must be followed:
 - `:::tip` — confirmation of expected outcomes
 
 **What to leave as `[TODO: docs reviewer — ...]` placeholders**
-- Screenshots (not captured by this skill)
+- Screenshots where computer use fails the quality gate, is unavailable, or the feature isn't yet shipped
 - Video/GIF embeds
 - Exact Settings path if the feature hasn't shipped yet
 - Final URL path (docs team confirms placement)
 - Any behavior that remained unverified after engineer confirmation
+
+---
+
+## Step 4.5: Capture screenshots via computer use (if available)
+
+After generating the draft, attempt to capture screenshots for any `[TODO: docs reviewer — screenshot needed]` placeholders using computer use. This step is **optional** — only run it if the `computer_use` tool is available. If computer use is unavailable, leave all placeholders as-is.
+
+### Decide which screenshots to attempt
+
+Only attempt screenshots where **all** of the following are true:
+- The feature is already shipped (not behind a feature flag or unreleased)
+- The UI state can be reliably navigated to programmatically
+- The placeholder specifies a concrete UI surface (not vague like "show the feature working")
+
+Skip screenshots that require account-specific state, specific data, or content that would expose sensitive information.
+
+### Pre-capture setup
+
+Before taking any screenshot:
+1. Launch Warp at a consistent window size (use the `warp-internal-computer-use` skill for launch guidance)
+2. Navigate to the relevant UI surface or trigger the relevant feature state
+3. **Wait** for all animations to complete and the UI to be fully settled
+4. Dismiss any unrelated popups, notifications, or toasts that aren't part of the feature being documented
+5. Close any sidebar panels or panes not relevant to this screenshot
+6. **Verify no sensitive data is visible**: check for tokens, API keys, private repo names, customer workspace data, email addresses, or personal information. If any is visible, do not take the screenshot.
+
+### Capture
+
+Take the screenshot. Then apply the quality gate before including it.
+
+### Quality gate — only include the screenshot if ALL pass
+
+- [ ] Text in the screenshot is **legible** at the target display size
+- [ ] The documented UI element is **clearly the focal point** — not buried, cropped out, or obscured
+- [ ] **No sensitive data** is visible (tokens, private repos, personal info, customer data)
+- [ ] UI is in a **stable, non-loading state** — no spinners, skeleton screens, or transitional states
+- [ ] The screenshot **accurately represents** the feature behavior described in the surrounding text
+- [ ] The screenshot would make sense at its target rendered width without looking blurry or oversized
+
+If any item fails, discard the screenshot and leave the `[TODO: docs reviewer — screenshot]` placeholder.
+
+### Sizing — choose the closest standard width
+
+- **Full-width (default)** — full-window captures, broad product surfaces, layouts where surrounding context matters
+- **~375px** — narrow UI surfaces: popovers, command menus, side panes, dropdowns, focused interaction flows
+- **~300–350px** — tightly cropped controls, chips, buttons, tooltips, small menus
+
+Crop unnecessary empty space before sizing. Keep sequences of screenshots in the same section at the same width.
+
+### Placement — where to insert the screenshot in the MDX
+
+Insert each screenshot:
+- **Immediately after** the paragraph that introduces the UI or state it shows
+- **Near configuration instructions** — show settings panels or menus where users make choices
+- **Near status or result explanations** — show completion states or outputs that help users recognize success
+- **At the start of a visual feature page** — use a broad orientation screenshot early
+
+Do **not** add a screenshot for every step in a procedure. Only add one where the visual genuinely aids comprehension.
+
+### MDX format
+
+```mdx
+<figure>
+  <img
+    src="../../../assets/<section>/<feature-name>-<ui-state>.png"
+    alt="[Descriptive alt text: what the image shows, not just 'screenshot']"
+  />
+  <figcaption>[Caption: complete sentence, ≤10 words, orient don’t instruct, no marketing language, sentence case, ends with period.]</figcaption>
+</figure>
+```
+
+**Alt text rules:**
+- Describe what the image shows, not just "screenshot"
+- ✅ `alt="Agent permissions settings with 'Always allow' selected for file reads"`
+- ❌ `alt="screenshot"` or `alt=""`
+
+**Caption rules:**
+- Orient the reader — describe what is shown, not what to do
+- Complete sentence, ≤10 words ideally, never exceed ~20 words
+- No marketing language (avoid "easily," "quickly," "powerful," "at a glance")
+- Don't repeat the prose — the caption adds context, not an echo
+- Don't list everything visible — name the subject
+- ✅ `<figcaption>The Environments page in the Oz web app.</figcaption>`
+- ❌ `<figcaption>Click the toast to jump to the agent’s session.</figcaption>` (procedural — put this in body text)
+
+**File naming:** lowercase, hyphens, descriptive — e.g. `agent-mode-permissions-panel.png`
+
+**File location:** Save PNGs to `src/assets/<section>/` in `warpdotdev/docs` (Astro optimizes them automatically).
 
 ---
 

--- a/.agents/skills/write-feature-docs/SKILL.md
+++ b/.agents/skills/write-feature-docs/SKILL.md
@@ -181,7 +181,7 @@ Mark these with `[TODO: docs reviewer — ...]` in the draft:
 
 ## No-spec fallback
 
-If `specs/<id>/PRODUCT.md` and `specs/<id>/TECH.md` don't exist, use `Ask_User_Question` to interview the engineer. Ask about:
+If `specs/<id>/PRODUCT.md` and `specs/<id>/TECH.md` don't exist, use `ask_user_question` to interview the engineer. Ask about:
 
 1. What this feature does in one sentence
 2. The 2–3 most important things a user can do with it

--- a/.agents/skills/write-feature-docs/SKILL.md
+++ b/.agents/skills/write-feature-docs/SKILL.md
@@ -223,20 +223,54 @@ Before taking any screenshot:
 5. Close any sidebar panels or panes not relevant to this screenshot
 6. **Verify no sensitive data is visible**: check for tokens, API keys, private repo names, customer workspace data, email addresses, or personal information. If any is visible, do not take the screenshot.
 
-### Capture
+### Capture protocol: predict → capture → verify → retry once
 
-Take the screenshot. Then apply the quality gate before including it.
+This is a structured self-verification loop. Do not skip it — it's the primary guard against wrong-state, wrong-crop, and wrong-framing captures.
 
-### Quality gate — only include the screenshot if ALL pass
+**Step 1: State the expectation before capturing**
+
+Before taking any screenshot, write out what you expect to see:
+
+```
+CAPTURE EXPECTATION
+  Subject:            [The specific UI element or surface being documented]
+  Expected elements:  [2-3 specific things that MUST be visible — e.g. a panel title, a button, a specific setting]
+  Expected state:     [The UI state — e.g. "Settings panel open", "Modal visible", "Feature active and showing output"]
+  Must not contain:   [Anything that must NOT be visible — e.g. sensitive data, unrelated popups, loading spinners]
+```
+
+**Step 2: Capture**
+
+Take the screenshot.
+
+**Step 3: View and verify against the expectation**
+
+Use computer use to view the captured image, then check it against the expectation:
+
+- Is the stated **subject** visible and clearly the focal point?
+- Are all **expected elements** present?
+- Is the UI in the **expected state** (not a transitional or loading state)?
+- Is anything from **must not contain** visible?
+- Is text **legible** at the target display width?
+
+If all pass → proceed to the quality gate.
+
+If any fail → **attempt once more**: re-navigate to the UI state, wait longer for the UI to settle, then re-capture and re-verify.
+
+If the second attempt also fails → **discard** the screenshot and leave the `[TODO: docs reviewer — screenshot]` placeholder. Do not include a screenshot you can't verify.
+
+**Step 4: Quality gate — final check before including**
 
 - [ ] Text in the screenshot is **legible** at the target display size
 - [ ] The documented UI element is **clearly the focal point** — not buried, cropped out, or obscured
 - [ ] **No sensitive data** is visible (tokens, private repos, personal info, customer data)
 - [ ] UI is in a **stable, non-loading state** — no spinners, skeleton screens, or transitional states
-- [ ] The screenshot **accurately represents** the feature behavior described in the surrounding text
+- [ ] Screenshot **matches the capture expectation** stated before capture
 - [ ] The screenshot would make sense at its target rendered width without looking blurry or oversized
 
 If any item fails, discard the screenshot and leave the `[TODO: docs reviewer — screenshot]` placeholder.
+
+> **Maximum attempts per screenshot: 2.** If both fail, move on.
 
 ### Sizing — choose the closest standard width
 

--- a/.agents/skills/write-feature-docs/SKILL.md
+++ b/.agents/skills/write-feature-docs/SKILL.md
@@ -385,7 +385,7 @@ The following outline was generated from the spec. **@<github-username>: please 
 - [What was confirmed, e.g. "Feature flag: `my_feature` in warp-internal"]
 ```
 
-3. Generate the full MDX draft (Step 4) using your best judgment for any unverified items, marking them with `[TODO: engineer to verify — ...]` inline
+3. Generate the full MDX draft (Step 4) with this constraint: **do not draft any content derived from `TECH.md` in ambient mode.** There is no engineer present to confirm what is confidential, so any detail that came exclusively from `TECH.md` (implementation internals, data model, server architecture, private API details) must be replaced with `[TODO: engineer to verify — pulled from TECH.md, confirm this is safe to publish]`. Only `PRODUCT.md` content and codebase-verified facts are safe to draft without confirmation.
 4. **Attempt screenshots** (Step 4.5) — if computer use is available, run the predict-then-verify capture protocol for any screenshot placeholders. Include any screenshots that pass the quality gate in the draft.
 5. Open the draft PR (Step 5) as normal — tag the spec author and docs reviewers
 6. Do not post any interactive messages to the terminal; all output should go into the PR

--- a/.agents/skills/write-feature-docs/SKILL.md
+++ b/.agents/skills/write-feature-docs/SKILL.md
@@ -232,7 +232,44 @@ Build the outline from your research and the engineer's targeted answers, then p
 
 ---
 
+## Ambient mode (called by scan-new-specs)
+
+When this skill is invoked by `scan-new-specs` rather than an engineer directly, it runs in **ambient mode** — there is no interactive terminal session, so the outline confirmation step must be handled differently.
+
+In ambient mode:
+
+1. Complete Steps 1 and 2 (read spec, research codebase) as normal
+2. **Skip the interactive outline confirmation.** Instead, embed the outline directly in the PR description as a checklist:
+
+```markdown
+## Docs outline (auto-generated)
+
+The following outline was generated from the spec. **@<github-username>: please review and check off each item, or leave a comment with corrections.**
+
+### Content structure
+- [ ] H1: `<feature name>`
+- [ ] Opening paragraph describes: [your 1-sentence summary]
+- [ ] Key features section covers: [which capabilities]
+- [ ] How it works section covers: [the conceptual model]
+- [ ] `## <Usage section>` with steps: [numbered list]
+- [ ] Related pages: [suggested cross-links]
+
+### Items needing engineer verification ⚠️
+- [ ] [UNVERIFIED item 1 — e.g. "Does this trigger automatically or require manual action?"]
+- [ ] [UNVERIFIED item 2]
+
+### Verified from codebase ✅
+- [What was confirmed, e.g. "Feature flag: `my_feature` in warp-internal"]
+```
+
+3. Generate the full MDX draft (Step 4) using your best judgment for any unverified items, marking them with `[TODO: engineer to verify — ...]` inline
+4. Open the draft PR (Step 5) as normal — tag the spec author and docs reviewers
+5. Do not post any interactive messages to the terminal; all output should go into the PR
+
+---
+
 ## Related skills
 
 - `write-product-spec` — produces the `PRODUCT.md` this skill reads
 - `write-tech-spec` — produces the `TECH.md` this skill reads
+- `scan-new-specs` — the scheduled agent that invokes this skill in ambient mode

--- a/.agents/skills/write-feature-docs/SKILL.md
+++ b/.agents/skills/write-feature-docs/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: write-feature-docs
+description: Draft the first ~80% documentation page for a new Warp feature from its PRODUCT.md and/or TECH.md spec. Use when an engineer has written a spec and needs to produce a first-pass MDX draft for the warpdotdev/docs repo. Also handles features without specs via an interactive interview. Invoke this skill whenever an engineer mentions writing docs for a feature, drafting a docs page, creating feature documentation, starting the eng-docs workflow, or converting a spec into documentation. Works from warp-internal or warp-server.
+---
+
+# write-feature-docs
+
+Draft the first ~80% documentation page for a new Warp feature. You read the feature's spec, generate a concise outline for the engineer to confirm, then produce a complete MDX draft ready for a draft PR to `warpdotdev/docs`.
+
+The engineer's job is to verify **technical accuracy** — not polish prose, fix formatting, or know docs conventions. Your job is everything else.
+
+## The workflow
+
+1. Find the spec files for the feature
+2. Generate a concise outline and present it in the terminal
+3. Engineer confirms the outline is accurate (or replies with corrections)
+4. Generate the full ~80% MDX draft from the confirmed outline
+5. Tell the engineer how to submit it as a draft PR to `warpdotdev/docs`
+
+---
+
+## Step 1: Find the spec
+
+Ask the engineer for the spec ID if they haven't provided it. The spec ID is one of:
+- A Linear ticket number: `APP-1234`
+- A GitHub issue (prefixed with `gh-`): `gh-4567`
+- A short kebab-case feature name: `vertical-tabs-hover-sidecar`
+
+Look for the spec files at:
+- `specs/<id>/PRODUCT.md` — primary source: user-facing behavior, what and why
+- `specs/<id>/TECH.md` — secondary source: implementation, data model
+
+Read both files if both exist. `PRODUCT.md` is the primary driver for the docs content. Reference `TECH.md` only to check technical accuracy and understand implementation constraints — don't let implementation details leak into the user-facing prose.
+
+If neither file exists, skip to [No-spec fallback](#no-spec-fallback).
+
+---
+
+## Step 2: Generate and present the outline
+
+Read the spec(s) and generate a concise outline. **The outline has no prose** — its purpose is to give the engineer a quick technical accuracy check before you write anything.
+
+Print the outline to the terminal in this format:
+
+```
+📄 Docs outline for [Feature name]
+
+PROPOSED PLACEMENT
+  Section:  src/content/docs/<section>/   (e.g., agent-platform/cloud-agents/)
+  File:     <feature-name>.mdx
+  URL:      docs.warp.dev/<path>/<feature-name>
+
+CONTENT SECTIONS
+  H1:  <Feature name>
+  Opening paragraph: [1-sentence description of what you'll write]
+  ## Key features — [which 2-4 capabilities to highlight as bullets]
+  ## How it works — [the conceptual model: what and why, no steps]
+  ## <Usage section title> — [e.g., "Creating environments", "Configuring X"]
+      Prerequisites: [any prerequisites to list]
+      Steps:
+        1. [Step description]
+        2. [Step description]
+        3. [Step description]
+        ...
+  ## Related pages — [cross-links to suggest]
+
+KEY TERMS TO VERIFY
+  - "<Term>": [your understanding — confirm this is accurate]
+  - "<Term>": [your understanding — confirm this is accurate]
+```
+
+After printing the outline, say:
+
+> "Does this outline accurately represent the feature? Reply with any corrections or say 'looks good' to proceed to the full draft."
+
+Wait for the engineer's reply before continuing. Their reply is a free-form terminal response — they may correct steps, rename concepts, add missing behavior, or just confirm. Incorporate their feedback before drafting.
+
+---
+
+## Step 3: Generate the MDX draft
+
+Generate a complete `.mdx` file based on the confirmed outline. The output should be ready to drop into `src/content/docs/<section>/<filename>.mdx` in the `warpdotdev/docs` repo.
+
+### Template structure
+
+```mdx
+---
+description: >-
+  [1-2 sentence standalone summary. Lead with the user benefit. Include the
+  feature name and a key term or two so it works as a search result snippet.]
+---
+
+# [Feature name]
+
+[Opening paragraph: what the feature does and its primary benefit.
+1-3 sentences. Lead with what the user can accomplish, not the implementation.]
+
+:::note
+[Optional: key context the reader needs upfront — a prerequisite, a limitation,
+or when NOT to use this feature. Delete this callout if nothing applies.]
+:::
+
+## Key features
+
+* **Feature A** - What it does and why it matters to the user.
+* **Feature B** - What it does and why it matters to the user.
+
+## How it works
+
+[CONCEPTUAL section: explain system behavior, data flow, or architecture.
+Answer "what" and "why" before "how." Define any new terms when they
+first appear. Do NOT include step-by-step procedures in this section —
+keep conceptual and procedural content clearly separated.]
+
+## [Usage section title]
+
+[PROCEDURAL section: motivate the task first, then give numbered steps.
+Briefly explain why the user is doing this before telling them how.]
+
+### Prerequisites
+
+* **[Prerequisite]** - What it is and where to get it. See [full reference](link-here).
+
+### [Task name — sentence case, e.g., "Create an environment with the CLI"]
+
+1. First step. Expected outcome if not obvious.
+2. Second step.
+3. Third step.
+
+## Related pages
+
+* [Related feature](../path/to/page.md)
+* [Deeper guide](../path/to/guide.md)
+```
+
+### Style rules — apply exactly
+
+These conventions come from the Warp docs style guide and must be followed:
+
+**Headings**
+- Sentence case for all headings: capitalize only the first word and proper feature names
+- Proper feature names keep their capitalization: "Agent Mode", "Warp Drive", "Oz", "Command Palette"
+- ✅ `## How it works` — ❌ `## How It Works`
+- ✅ `## Agent Mode settings` — ❌ `## Agent mode settings`
+
+**Lists**
+- Bold term + dash + description: `* **Term** - Description`
+- Never use a colon: ❌ `* **Term**: Description`
+
+**UI elements and paths**
+- Bold for buttons, links, menu items: `Click **Save**`, not `` Click `Save` ``
+- Bold each segment in a Settings path, leave `>` plain: `**Settings** > **AI** > **Knowledge**`
+
+**Voice and tone**
+- Second person: "you can," "allows you to"
+- Active voice: "Warp indexes your codebase" — not "your codebase is indexed"
+- Avoid "simple," "easy," "just" — these dismiss the reader's experience
+- Present tense for how things work; imperative for instructions
+
+**Frontmatter description**
+- Write as a standalone summary that works as a search result snippet
+- Lead with user benefit, include the feature name and key terms
+- ✅ `Environments ensure your cloud agents run with a consistent toolchain. Learn when to use environments and how to configure them.`
+- ❌ `This page describes environments.`
+
+**Callout syntax** (Astro Starlight)
+- `:::note` — supplemental context, tips
+- `:::caution` — caveats, limitations
+- `:::danger` — destructive or irreversible actions
+- `:::tip` — confirmation of expected outcomes
+
+**What to leave as placeholders**
+Mark these with `[TODO: docs reviewer — ...]` in the draft:
+- Screenshots (you can't capture live UI)
+- Video/GIF embeds
+- Exact Settings path if the feature hasn't shipped yet
+- Final URL path (docs team confirms placement)
+- Any behavior you're uncertain about after reading the spec
+
+---
+
+## No-spec fallback
+
+If `specs/<id>/PRODUCT.md` and `specs/<id>/TECH.md` don't exist, use `Ask_User_Question` to interview the engineer. Ask about:
+
+1. What this feature does in one sentence
+2. The 2–3 most important things a user can do with it
+3. The step-by-step actions a user takes to use it
+4. Any prerequisites, limitations, or gotchas the reader needs to know
+5. Any related features or pages to cross-reference
+
+Build the outline from their answers, then present it for confirmation (Step 2) before drafting. Don't skip the outline confirmation step — it's the engineer's technical accuracy check regardless of whether a spec exists.
+
+---
+
+## Step 4: Handoff instructions
+
+After presenting the draft, tell the engineer:
+
+> "Here's your ~80% draft. To hand it off for docs review:
+>
+> 1. Save this file to the `warpdotdev/docs` repo at the proposed path above
+> 2. Add an entry for it in `src/sidebar.ts` under the appropriate section
+> 3. Open a **draft PR** in `warpdotdev/docs` — feature docs PRs don't need to be kept private before launch
+>
+> The docs team will take it from there: terminology, readability, screenshots, final placement, navigation, and redirects."
+
+---
+
+## Related skills
+
+- `write-product-spec` — produces the `PRODUCT.md` this skill reads
+- `write-tech-spec` — produces the `TECH.md` this skill reads

--- a/.agents/skills/write-feature-docs/SKILL.md
+++ b/.agents/skills/write-feature-docs/SKILL.md
@@ -16,7 +16,8 @@ The engineer's job is to confirm what you couldn't verify from the spec and code
 3. Generate a concise outline, distinguishing verified facts from open questions
 4. Engineer confirms or corrects
 5. Generate the complete MDX draft
-6. Open a draft PR in `warpdotdev/docs` and tag the docs team
+6. Attempt screenshot capture via computer use (if available)
+7. Open a draft PR in `warpdotdev/docs` and tag the docs team
 
 ---
 
@@ -385,8 +386,9 @@ The following outline was generated from the spec. **@<github-username>: please 
 ```
 
 3. Generate the full MDX draft (Step 4) using your best judgment for any unverified items, marking them with `[TODO: engineer to verify — ...]` inline
-4. Open the draft PR (Step 5) as normal — tag the spec author and docs reviewers
-5. Do not post any interactive messages to the terminal; all output should go into the PR
+4. **Attempt screenshots** (Step 4.5) — if computer use is available, run the predict-then-verify capture protocol for any screenshot placeholders. Include any screenshots that pass the quality gate in the draft.
+5. Open the draft PR (Step 5) as normal — tag the spec author and docs reviewers
+6. Do not post any interactive messages to the terminal; all output should go into the PR
 
 ---
 

--- a/.agents/skills/write-feature-docs/SKILL.md
+++ b/.agents/skills/write-feature-docs/SKILL.md
@@ -218,7 +218,7 @@ After generating the draft, submit it to `warpdotdev/docs` automatically:
 
 ## No-spec fallback
 
-If `specs/<id>/PRODUCT.md` and `specs/<id>/TECH.md` don't exist, research the codebase first — do not start by interviewing the engineer.
+If `specs/<id>/PRODUCT.md` and `specs/<id>/TECH.md` don't exist, research the codebase first before interviewing the engineer.
 
 **Research steps:**
 1. Search `warpdotdev/warp-internal` (or `warp-server` depending on context) for the feature name and related terms: `gh search code "<feature-name>" --repo warpdotdev/warp-internal`

--- a/.agents/skills/write-feature-docs/SKILL.md
+++ b/.agents/skills/write-feature-docs/SKILL.md
@@ -1,25 +1,26 @@
 ---
 name: write-feature-docs
-description: Draft the first ~80% documentation page for a new Warp feature from its PRODUCT.md and/or TECH.md spec. Use when an engineer has written a spec and needs to produce a first-pass MDX draft for the warpdotdev/docs repo. Also handles features without specs via an interactive interview. Invoke this skill whenever an engineer mentions writing docs for a feature, drafting a docs page, creating feature documentation, starting the eng-docs workflow, or converting a spec into documentation. Works from warp-internal or warp-server.
+description: Draft a complete documentation page for a new Warp feature from its PRODUCT.md and/or TECH.md spec. Use when an engineer has written a spec and needs to produce a first-pass MDX draft for the warpdotdev/docs repo. Also handles features without specs by researching the codebase first. Invoke this skill whenever an engineer mentions writing docs for a feature, drafting a docs page, creating feature documentation, starting the eng-docs workflow, or converting a spec into documentation. Works from warp-internal or warp-server.
 ---
 
 # write-feature-docs
 
-Draft the first ~80% documentation page for a new Warp feature. You read the feature's spec, generate a concise outline for the engineer to confirm, then produce a complete MDX draft ready for a draft PR to `warpdotdev/docs`.
+Draft a complete documentation page for a new Warp feature. You read the feature's spec, verify technical claims by researching the codebase yourself, present a concise outline for the engineer to confirm, then produce a complete MDX draft and open a draft PR in `warpdotdev/docs` — tagging the docs team for review.
 
-The engineer's job is to verify **technical accuracy** — not polish prose, fix formatting, or know docs conventions. Your job is everything else.
+The engineer's job is to confirm what you couldn't verify from the spec and code — not to do a full accuracy review, not to polish prose, not to know docs conventions.
 
 ## The workflow
 
-1. Find the spec files for the feature
-2. Generate a concise outline and present it in the terminal
-3. Engineer confirms the outline is accurate (or replies with corrections)
-4. Generate the full ~80% MDX draft from the confirmed outline
-5. Tell the engineer how to submit it as a draft PR to `warpdotdev/docs`
+1. Find and read the spec files
+2. Research the codebase to verify technical claims — minimize what the engineer needs to check
+3. Generate a concise outline, distinguishing verified facts from open questions
+4. Engineer confirms or corrects
+5. Generate the complete MDX draft
+6. Open a draft PR in `warpdotdev/docs` and tag the docs team
 
 ---
 
-## Step 1: Find the spec
+## Step 1: Find and read the spec
 
 Ask the engineer for the spec ID if they haven't provided it. The spec ID is one of:
 - A Linear ticket number: `APP-1234`
@@ -30,15 +31,32 @@ Look for the spec files at:
 - `specs/<id>/PRODUCT.md` — primary source: user-facing behavior, what and why
 - `specs/<id>/TECH.md` — secondary source: implementation, data model
 
-Read both files if both exist. `PRODUCT.md` is the primary driver for the docs content. Reference `TECH.md` only to check technical accuracy and understand implementation constraints — don't let implementation details leak into the user-facing prose.
+Read both files if both exist. `PRODUCT.md` is the primary driver for the docs content.
+
+**When reading `TECH.md`:** Before incorporating anything from it, identify content that looks like internal implementation detail — database schema, internal service names, private API endpoints, confidential server architecture. Present these flagged items to the engineer and ask them to confirm what's safe to include in public docs and what should stay internal. Do not include anything marked confidential in the draft.
 
 If neither file exists, skip to [No-spec fallback](#no-spec-fallback).
 
 ---
 
-## Step 2: Generate and present the outline
+## Step 2: Research the codebase
 
-Read the spec(s) and generate a concise outline. **The outline has no prose** — its purpose is to give the engineer a quick technical accuracy check before you write anything.
+Before presenting the outline, use the GitHub CLI to verify as much technical content as possible yourself — reducing what the engineer needs to confirm to only what you genuinely cannot determine from the code.
+
+Things to verify from code:
+- **Feature flag name**: `gh search code "<feature-name>" --repo warpdotdev/warp-internal`
+- **UI strings**: search for user-visible button labels, menu item names, or setting names referenced in the spec
+- **Settings paths**: confirm exact Settings menu paths (e.g., `**Settings** > **AI** > **Knowledge**`)
+- **CLI commands or keyboard shortcuts** mentioned in the spec
+- **Related features**: identify other features that cross-reference this one for "Related pages"
+
+For each claim you verify from code, mark it confirmed. For claims you can't verify (UI behavior not in code, product intent, behavior of unreleased features), flag them as `[UNVERIFIED]` in the outline — those are the only things the engineer needs to focus on.
+
+---
+
+## Step 3: Generate and present the outline
+
+Generate a concise outline — no prose. The outline shows what you've confirmed from research and exactly what still needs engineer input.
 
 Print the outline to the terminal in this format:
 
@@ -64,22 +82,26 @@ CONTENT SECTIONS
         ...
   ## Related pages — [cross-links to suggest]
 
-KEY TERMS TO VERIFY
-  - "<Term>": [your understanding — confirm this is accurate]
-  - "<Term>": [your understanding — confirm this is accurate]
+VERIFIED FROM CODEBASE ✅
+  - [e.g., "Feature flag: `my_feature_flag` confirmed in warp-internal"]
+  - [e.g., "Settings path: confirmed as Settings > AI > Agents > Permissions"]
+
+NEEDS YOUR CONFIRMATION ⚠️
+  - [e.g., "Step 3 — does the sync trigger automatically or require a manual action?"]
+  - [e.g., "Is the 'Export' button visible before the feature flag is enabled?"]
 ```
 
 After printing the outline, say:
 
-> "Does this outline accurately represent the feature? Reply with any corrections or say 'looks good' to proceed to the full draft."
+> "I've verified what I could from the codebase. Please check the items marked ⚠️ above and reply with any corrections, or say 'looks good' to proceed."
 
-Wait for the engineer's reply before continuing. Their reply is a free-form terminal response — they may correct steps, rename concepts, add missing behavior, or just confirm. Incorporate their feedback before drafting.
+Wait for the engineer's reply before continuing. Incorporate their feedback, then draft.
 
 ---
 
-## Step 3: Generate the MDX draft
+## Step 4: Generate the MDX draft
 
-Generate a complete `.mdx` file based on the confirmed outline. The output should be ready to drop into `src/content/docs/<section>/<filename>.mdx` in the `warpdotdev/docs` repo.
+Generate a complete `.mdx` file based on the confirmed outline. The output is ready to drop directly into `warpdotdev/docs`.
 
 ### Template structure
 
@@ -169,41 +191,44 @@ These conventions come from the Warp docs style guide and must be followed:
 - `:::danger` — destructive or irreversible actions
 - `:::tip` — confirmation of expected outcomes
 
-**What to leave as placeholders**
-Mark these with `[TODO: docs reviewer — ...]` in the draft:
-- Screenshots (you can't capture live UI)
+**What to leave as `[TODO: docs reviewer — ...]` placeholders**
+- Screenshots (not captured by this skill)
 - Video/GIF embeds
 - Exact Settings path if the feature hasn't shipped yet
 - Final URL path (docs team confirms placement)
-- Any behavior you're uncertain about after reading the spec
+- Any behavior that remained unverified after engineer confirmation
+
+---
+
+## Step 5: Open the draft PR
+
+After generating the draft, submit it to `warpdotdev/docs` automatically:
+
+1. Clone `warpdotdev/docs` to a temp directory (or use the local clone if available)
+2. Write the MDX file to `src/content/docs/<proposed-section>/<filename>.mdx`
+3. Add a placeholder entry to `src/sidebar.ts` under the appropriate section (mark it `[TODO: docs reviewer — confirm placement]`)
+4. Commit and push on a new branch named `docs/<spec-id>-feature-draft`
+5. Open a **draft PR** in `warpdotdev/docs` with a description that includes:
+   - The feature name and spec ID
+   - A link to the original spec PR
+   - A list of all `[UNVERIFIED]` and `[TODO]` items in the draft for reviewer attention
+6. Request review from `@rachaelrenk`, `@petradonka`, and `@hongyi-chen`
 
 ---
 
 ## No-spec fallback
 
-If `specs/<id>/PRODUCT.md` and `specs/<id>/TECH.md` don't exist, use `ask_user_question` to interview the engineer. Ask about:
+If `specs/<id>/PRODUCT.md` and `specs/<id>/TECH.md` don't exist, research the codebase first — do not start by interviewing the engineer.
 
-1. What this feature does in one sentence
-2. The 2–3 most important things a user can do with it
-3. The step-by-step actions a user takes to use it
-4. Any prerequisites, limitations, or gotchas the reader needs to know
-5. Any related features or pages to cross-reference
+**Research steps:**
+1. Search `warpdotdev/warp-internal` (or `warp-server` depending on context) for the feature name and related terms: `gh search code "<feature-name>" --repo warpdotdev/warp-internal`
+2. Read the most relevant source files to understand what the feature does
+3. Check for spec files under a different ID: `gh api repos/warpdotdev/warp-internal/git/trees/HEAD?recursive=1 | grep -i spec`
+4. Review recent merged PRs related to the feature: `gh pr list --search "<feature-name>" --state merged --repo warpdotdev/warp-internal --limit 10`
 
-Build the outline from their answers, then present it for confirmation (Step 2) before drafting. Don't skip the outline confirmation step — it's the engineer's technical accuracy check regardless of whether a spec exists.
+**After research,** build as complete a picture as possible, then use `ask_user_question` only for specific gaps you couldn't fill from the code — not as a broad interview. Frame the questions concretely: "I found the feature in `app/src/ai/`. Based on the code, here's what I understand: [summary]. I couldn't determine these two things: [specific questions]."
 
----
-
-## Step 4: Handoff instructions
-
-After presenting the draft, tell the engineer:
-
-> "Here's your ~80% draft. To hand it off for docs review:
->
-> 1. Save this file to the `warpdotdev/docs` repo at the proposed path above
-> 2. Add an entry for it in `src/sidebar.ts` under the appropriate section
-> 3. Open a **draft PR** in `warpdotdev/docs` — feature docs PRs don't need to be kept private before launch
->
-> The docs team will take it from there: terminology, readability, screenshots, final placement, navigation, and redirects."
+Build the outline from your research and the engineer's targeted answers, then proceed to Step 3 (outline confirmation) before drafting.
 
 ---
 


### PR DESCRIPTION
## What this PR adds

Two companion skills for an automated eng-owned docs workflow:

- **`write-feature-docs`** -- generates a complete documentation draft from a feature spec
- **`scan-new-specs`** -- scheduled Oz ambient agent that detects new specs and triggers the drafting workflow automatically

---

## How the workflow fits together

A scheduled Oz agent runs `scan-new-specs` every few days. For each new spec merged to `warpdotdev/warp` or `warp-server` without a corresponding docs PR:

- **Complete spec** (40+ lines, Behavior section) -- the agent auto-runs `write-feature-docs` in ambient mode, opens a draft PR in `warpdotdev/docs`, tags the engineer and docs team as reviewers, and posts a Slack notification to `#growth-docs`.
- **Thin spec** (stub, no behavior detail) -- the agent posts a Slack message to `#growth-docs` asking the engineer to flesh out the spec or reach out to the docs team.

After the draft PR is open, the docs team handles terminology, readability, visuals, final placement, navigation, and redirects before publishing.

---

## The two modes of write-feature-docs

### Interactive mode (engineer-invoked)

An engineer runs this skill directly from `warp-internal` or `warp-server`.

Flow:
1. Reads `specs/<id>/PRODUCT.md` and `TECH.md` -- flags confidential TECH.md content for engineer review before including anything in public docs
2. Researches the codebase via `gh` CLI -- verifies feature flags, UI strings, Settings paths, keyboard shortcuts
3. Prints a concise outline to the terminal with VERIFIED FROM CODEBASE and NEEDS YOUR CONFIRMATION sections
4. Engineer replies in the terminal with corrections or confirms
5. Generates the complete MDX draft
6. Attempts screenshot capture via computer use (see protocol below)
7. Opens a draft PR in `warpdotdev/docs` and tags docs reviewers

No-spec fallback: researches the codebase first (gh search, source files, recent PRs), then uses `ask_user_question` only for specific gaps it could not determine from code.

### Ambient mode (called by scan-new-specs)

When invoked by the scheduled scanner, there is no interactive terminal session.

Key differences from interactive mode:
- Skips the terminal outline prompt
- Embeds the outline as a PR description checklist for the engineer to review asynchronously
- Unverified items become PR checklist items marked [TODO: engineer to verify]
- Screenshots still attempted if computer use is available

---

## Screenshot capture protocol

Step 4.5 (between draft generation and PR opening) attempts to capture screenshots for screenshot placeholders using computer use.

Protocol: predict -> capture -> verify -> retry once
1. State a CAPTURE EXPECTATION block before capturing: subject, expected elements, expected state, must-not-contain
2. Capture the screenshot
3. View the image and verify it matches the stated expectation
4. If any check fails: retry once (re-navigate, wait longer)
5. If second attempt also fails: discard, leave a docs-reviewer placeholder

Quality gate (all must pass): legibility at target display width, focal-point clarity, no sensitive data, stable UI state, matches stated expectation.

Sizing (from `AGENTS.md`): full-width for broad surfaces / ~375px for narrow UI (popovers, side panes) / ~300-350px for controls and tooltips.

Max 2 attempts per screenshot. This is experimental and quality will improve with iteration.

---

## scan-new-specs: detection and action

Trigger: scheduled Oz ambient agent (suggested: Mon/Wed/Fri at 9am PT).

Complete spec (40+ lines, Behavior section, at least one user-facing step): auto-run `write-feature-docs` in ambient mode, open draft PR, tag engineer.

Thin spec (stub, fewer than 40 lines, no behavior detail): Slack ping to the engineer asking them to flesh out the spec or request manual drafting.

GitHub to Slack user ID mapping: resolves the engineer's GitHub email, then looks up their Slack user ID via `users.lookupByEmail`. Uses real Slack pings so engineers receive an actual notification. Falls back to plain-text name if the engineer has a private GitHub email.

Deduplication: PR-based. A spec is covered once any open/merged/draft PR exists in `warpdotdev/docs`. Closed PRs are treated as uncovered -- this is intentional, since a closed PR signals abandoned work that needs re-triggering.

---

## What needs to happen to activate this

After merging:

1. Schedule the Oz agent -- in the Oz web app, create a scheduled agent using the buzz Oz environment (which already has `SLACK_BOT_TOKEN` and GitHub access) with the `scan-new-specs` skill.

2. No new secrets needed -- `SLACK_BOT_TOKEN` is already in the buzz environment. The skill uses chat.postMessage, not a webhook, so no webhook URL setup is required.

3. Choose the right Slack channel -- #growth-docs is temporary. Identify a more eng-facing channel once the workflow is established (see TODO in skill).

Note: the existing `SLACK_WEBHOOK_URL` secret in buzz points to a different channel and is not used by this skill.

---

## Feedback requested

1. Outline confirmation step (`write-feature-docs` interactive mode)
- Does showing engineers an outline for confirmation first feel like the right tradeoff, or would they prefer to skip to reviewing the full draft?

2. Automated trigger (`scan-new-specs`)
- #growth-docs is a temporary channel; need to identify an existing, eng-facing Slack channel for these notifications.
- Is Mon/Wed/Fri the right cadence?

3. Screenshot capture
- Does the predict-then-verify quality gate feel right? Too strict, too lenient, or missing something?
- Are there UI surfaces that would be hard to navigate to programmatically?

Co-Authored-By: Oz <oz-agent@warp.dev>
