### PR TITLE
Add `research` and `cross-critique` skills.

### DIFF
--- a/.agents/skills/cross-critique/SKILL.md
+++ b/.agents/skills/cross-critique/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: cross-critique
+description: Run a second round on a contested question by circulating each subagent's independent proposal to the other authors and asking for structured pros and cons, then synthesize. Use this skill whenever you have multiple independent proposals or opinions on a contested decision — architecture tradeoffs, code review disagreements, design choices, competing root-cause theories — and want sharper analysis than you'd produce by synthesizing alone. Pairs naturally with the council and research skills; reach for it liberally whenever proposals diverge.
+---
+
+# Cross-Critique
+
+Use this skill to run a **second round** after several subagents have independently produced proposals or opinions on the same contested question. Instead of synthesizing their reports yourself, you circulate each proposal to the *other* authors and ask them to critique it — pros and cons — and then you synthesize the richer set of analyses that results.
+
+## Why this matters
+
+When you generate independent proposals (different models, different angles), each author ends up with deep context on the question — often deeper than yours, since they did the investigation. If you jump straight to synthesizing their reports alone, you're the bottleneck: you can only see the tradeoffs *you* happen to notice.
+
+Asking the authors to critique each other is what a good leader does when seeking advice: get a few people with differing perspectives in a room, let them poke holes in each other's reasoning, and you walk away with a far more complete picture than any one of them — or you — would produce alone. The authors will surface failure modes, hidden assumptions, and tradeoffs that neither you nor the original proposer flagged.
+
+## When to use it
+
+Use cross-critique when a decision is **contested** — i.e. independent agents produced genuinely divergent proposals, or the question is subjective enough that reasonable approaches disagree. Good fits:
+
+- Architecture and design tradeoffs.
+- Code review where reviewers reached different conclusions.
+- Competing root-cause theories for a bug.
+- Code-structure or API-shape decisions with no single right answer.
+
+Don't bother when the proposals already strongly agree, or when the question has an objective answer you can verify directly — critique adds latency and tokens, and its value comes specifically from resolving genuine disagreement. Within that scope, use it freely; you don't need a high-stakes justification, just real divergence worth resolving.
+
+## Prerequisite: you need independent proposals first
+
+This skill is the *second* round. It assumes you already have N independent proposals in hand. If you don't yet:
+
+- For a judgment-heavy decision, generate them with the **council** skill (model-diverse subagents on the same question).
+- For an investigation-heavy question, generate them by spawning parallel subagents (see the **research** skill).
+- Or use any ad-hoc set of independent subagent proposals you've already collected.
+
+Critically, the first round must be **independent** — do not let the authors see each other's work during round one, or you lose the diversity that makes round two valuable.
+
+## How to do it
+
+### 1. Assemble the proposals
+
+Collect each author's proposal. Keep them concise — the core recommendation and its reasoning, not the full transcript. Consider labeling them neutrally (Proposal A, B, C) and, where practical, anonymizing authorship to reduce bandwagon bias toward whichever model sounds most confident.
+
+### 2. Circulate and ask for structured critique
+
+Reuse the **same subagents** from round one rather than spawning fresh ones — they retain their context and can critique from a position of understanding. Send each author the *other* proposals (not their own) and ask each for:
+
+- For each alternative: its **pros** (what it gets right, where it's stronger than my approach) and its **cons** (risks, edge cases, hidden costs, wrong assumptions).
+- Whether, having seen the alternatives, they would **revise their own** recommendation — and why or why not.
+- A final ranking or recommendation with confidence.
+
+Insist on *both* pros and cons for each alternative. An honest critique that credits a rival's strengths is far more useful than a reflexive defense of one's own proposal.
+
+### 3. Synthesize
+
+Now bring it together yourself. Compare critiques by **evidence quality, not vote count**. In your final answer:
+
+- Lead with the recommendation.
+- Note where the authors converged after seeing each other's work — convergence in round two is a strong signal.
+- Surface the most incisive cons raised against each option.
+- Explain why the recommended option survives critique best against the decision criteria.
+- Call out remaining disagreement, confidence, and material unknowns.
+
+## Final answer template
+
+Use this shape unless the task calls for something different:
+
+```markdown
+## Recommendation
+[One or two sentences with the decision.]
+
+## How the critiques shifted things
+- [Where authors converged or changed their minds after seeing alternatives]
+- [The strongest objection raised, and whether it's decisive]
+
+## Why this option wins
+- [Reason grounded in the critiques]
+
+## Remaining risks and unknowns
+- [Open question or caveat]
+```
+
+## Practical notes
+
+- Keep the critique round read-only unless the underlying task explicitly involves making changes.
+- Don't expose internal subagent IDs in user-facing summaries unless the user asks.
+- If a critique is thin or unsupported, send a focused follow-up to that same author rather than discarding it.

--- a/.agents/skills/research/SKILL.md
+++ b/.agents/skills/research/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: research
+description: Delegate noisy investigation to one or more subagents so the orchestrator's context stays clean, then work from the distilled answer. Use this skill whenever answering a question would require reading many files, long logs, large diffs, or wide codebase surveys — i.e. when producing the answer generates far more noise than the answer itself. Use it for "how does X work", "where is Y used", "what's the root cause of Z", "summarize this PR/log" style questions, and reach for it liberally before reading a pile of files inline.
+---
+
+# Research
+
+Use this skill to answer a question by delegating the *work of finding the answer* to a subagent, so that the byproducts of that work — file contents, log noise, dead-end reads — never enter your own context. You get back a distilled answer plus the evidence that supports it, and you stay sharp for the actual task.
+
+## Why this matters
+
+Your context window is your most valuable and limited resource. Reading twenty files to discover that three of them mattered permanently pollutes your context with seventeen files of noise, degrading every subsequent decision you make. A subagent absorbs that noise on your behalf and hands you only the signal. Think of it as asking a colleague to dig through the archives and report back, rather than dumping the whole archive on your desk.
+
+## When to use it
+
+Reach for research delegation when **the cost of producing the answer is far greater than the answer itself**. Strong signals:
+
+- You'd need to read many files to find the few that are relevant.
+- You'd need to wade through long test output, CI logs, or stack traces to extract a failure.
+- You'd need to survey how a pattern, API, or symbol is used across the whole repo.
+- You'd need to read and summarize a large diff or PR.
+- The question has several independent sub-parts that could be investigated separately.
+
+**Examples — good fits:**
+
+- "What's the root cause of this failing test?" (the subagent reads the logs and traces the code; you get the cause)
+- "How is `SessionManager` used across the codebase?" (the subagent greps and reads; you get a summary with call sites)
+- "Summarize what this 4,000-line PR changes and why." (the subagent reads the diff; you get the shape of it)
+
+**Examples — do NOT delegate:**
+
+- Reading 2–3 files you already know you need. Just read them directly; delegation adds latency for no context savings.
+- A single `grep` or one-line lookup. Do it yourself.
+- **Anything where you need the raw material for your next step.** If you're about to *edit* the files you'd be reading, delegating is counterproductive — you'd just have to re-read them yourself to make the change. Research delegation pays off when the output is a *conclusion*, not when it's *material you'll work on directly*.
+
+The cost of a subagent is real (latency and tokens), so the test is always: does the noise I'd avoid outweigh that cost?
+
+## How to do it
+
+### Single vs. parallel
+
+Default to a **single subagent**. Spawn **multiple subagents in parallel** only when the question genuinely decomposes into independent sub-parts that don't need to share intermediate findings — for example, "how does auth work AND how does billing work AND how does the rate limiter work" are three independent investigations that can run at once. Parallelism is a capability worth using when the parts are truly independent, since separate subagents can investigate simultaneously; but don't force a single coherent question into artificial fragments.
+
+### Brief the subagent well
+
+The subagent does not share your intent, so spell it out. A good research brief includes:
+
+- The exact question to answer.
+- Where to look (repo path, branch, suspected files/symbols if you know them).
+- That it is **read-only** — it should investigate and report, not modify files, unless the task explicitly calls for changes.
+- The output you want back (see below).
+
+### Ask for signal, not transcript
+
+Tell the subagent to return a **distilled answer plus its supporting evidence**, not a raw dump. Specifically:
+
+1. The direct answer to the question.
+2. The key evidence: exact file paths and symbols (e.g. `src/session.rs:142`, `fn reconnect`), so you can jump straight to what matters.
+3. Anything surprising or any caveats/unknowns it hit.
+
+The whole point is that the noise stays with the subagent. If a report comes back bloated, send a focused follow-up to the *same* subagent asking it to tighten the answer — it retains its context and can refine cheaply.
+
+## After you get the answer
+
+Work from the distilled result. If you later find you need the underlying files to make edits, read them directly at that point — now you know exactly which ones matter, so you read three files instead of twenty.


### PR DESCRIPTION
This adds two skills to the `common-skills` repo that I've been using for the past couple weeks and have found helpful:
1. A `/research` skill, which the agent can use to spawn a subagent to do research that has a low signal-to-noise ratio, so that it can get the signal (subagent response) without the noise polluting its context window.
2. A `/cross-critique` skill, which the agent can use alongside the existing `/council` skill, telling the orchestrator how to get a council of agents to come to an agreement when they produce differing suggestions in response to some query.

I have a personal rule that helps with getting these to trigger; we'll see to what extent they trigger without that rule (and I can use that to do some tuning).