### PR TITLE
Automate the process of creating PRs to update lockfiles in other repos.

### DIFF
--- a/.github/workflows/update-downstream-skill-locks.yml
+++ b/.github/workflows/update-downstream-skill-locks.yml
@@ -25,7 +25,7 @@ jobs:
             base_branch: develop
     steps:
       - name: Check out common-skills
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: common-skills
           persist-credentials: false
@@ -61,7 +61,7 @@ jobs:
 
       - name: Generate target GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.COMMON_SKILLS_SYNC_APP_ID }}
           private-key: ${{ secrets.COMMON_SKILLS_SYNC_APP_PRIVATE_KEY }}
@@ -71,7 +71,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Check out target repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ matrix.repository }}
           ref: ${{ matrix.base_branch }}
@@ -92,7 +92,7 @@ jobs:
       - name: Create downstream pull request
         if: steps.update.outputs.changed == 'true'
         id: create-pr
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           path: target

--- a/.github/workflows/update-downstream-skill-locks.yml
+++ b/.github/workflows/update-downstream-skill-locks.yml
@@ -1,0 +1,137 @@
+name: Update downstream common-skills lockfiles
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  update-lockfile:
+    name: Update ${{ matrix.repository }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: warpdotdev/warp
+            repository_name: warp
+            base_branch: master
+          - repository: warpdotdev/warp-server
+            repository_name: warp-server
+            base_branch: develop
+    steps:
+      - name: Check out common-skills
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          path: common-skills
+          persist-credentials: false
+
+      - name: Resolve source pull request
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REPOSITORY: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          source_pr="$(
+            gh api "repos/${SOURCE_REPOSITORY}/commits/${SOURCE_SHA}/pulls" \
+              --jq '[.[] | select(.merged_at != null and .base.ref == "main")][0] // {}'
+          )"
+          source_pr_number="$(jq -r '.number // empty' <<< "${source_pr}")"
+          source_pr_author="$(jq -r '.user.login // empty' <<< "${source_pr}")"
+          source_pr_url="$(jq -r '.html_url // empty' <<< "${source_pr}")"
+
+          if [[ -n "${source_pr_number}" ]]; then
+            {
+              echo "author=${source_pr_author}"
+              echo "label=warpdotdev/common-skills#${source_pr_number}"
+              echo "url=${source_pr_url}"
+            } >> "${GITHUB_OUTPUT}"
+          else
+            {
+              echo "author="
+              echo "label=${SOURCE_SHA}"
+              echo "url=https://github.com/${SOURCE_REPOSITORY}/commit/${SOURCE_SHA}"
+            } >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Generate target GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
+        with:
+          app-id: ${{ vars.COMMON_SKILLS_SYNC_APP_ID }}
+          private-key: ${{ secrets.COMMON_SKILLS_SYNC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ matrix.repository_name }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Check out target repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          repository: ${{ matrix.repository }}
+          ref: ${{ matrix.base_branch }}
+          path: target
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Update target lockfile
+        id: update
+        run: |
+          common-skills/scripts/update_common_skills_lock --repo-root target
+          if git -C target diff --quiet -- skills-lock.json; then
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Create downstream pull request
+        if: steps.update.outputs.changed == 'true'
+        id: create-pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          path: target
+          add-paths: skills-lock.json
+          base: ${{ matrix.base_branch }}
+          branch: automation/common-skills-lock-${{ github.sha }}
+          delete-branch: true
+          commit-message: Update common skills lock for ${{ steps.source.outputs.label }}
+          title: Update common skills lock for ${{ steps.source.outputs.label }}
+          body: |
+            ## Description
+
+            Updates `skills-lock.json` to distribute the common skills from [${{ steps.source.outputs.label }}](${{ steps.source.outputs.url }}).
+
+            ## Testing
+
+            Generated with `scripts/update_common_skills_lock`.
+
+      - name: Request source author as reviewer
+        if: steps.create-pr.outputs.pull-request-number != '' && steps.source.outputs.author != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PULL_REQUEST_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+          REVIEWER: ${{ steps.source.outputs.author }}
+          TARGET_REPOSITORY: ${{ matrix.repository }}
+        run: |
+          if gh api \
+            --method POST \
+            "repos/${TARGET_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}/requested_reviewers" \
+            -f "reviewers[]=${REVIEWER}" >/dev/null; then
+            echo "Requested ${REVIEWER} as reviewer."
+          else
+            echo "::warning::Could not request ${REVIEWER} as reviewer; the pull request remains open."
+          fi
+
+      - name: Enable squash auto-merge
+        if: steps.create-pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PULL_REQUEST_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+          TARGET_REPOSITORY: ${{ matrix.repository }}
+        run: gh pr merge "${PULL_REQUEST_NUMBER}" --repo "${TARGET_REPOSITORY}" --auto --squash

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Each skill lives in its own directory under `.agents/skills/`. The only required
 - `review-pr` — produces structured PR review feedback from local diff artifacts.
 - `check-impl-against-spec` — compares PR implementation changes against provided spec context during review.
 
+### Investigation and decision-making
+
+- `research` — delegates low signal-to-noise-ratio research work to subagents and returns distilled, evidence-backed findings.
+- `cross-critique` — sharpens contested decisions by having agents critique one another's independent proposals before synthesis.
+
 ### Skill authoring
 
 - `update-skill` — guidance for creating and maintaining skill directories and `SKILL.md` files.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,6 +3,7 @@ These scripts help consuming repositories install, remove, and verify shared age
 ## Files
 - `resolve_common_skills`: resolves and executes scripts from this directory, a local override directory, or raw GitHub.
 - `install_common_skills`: installs or updates common skills, then verifies the installed contents.
+- `update_common_skills_lock`: regenerates an existing common-skills lockfile without installing skills.
 - `remove_common_skills`: removes installed common skills from a selected target.
 ## Quick start
 Install common skills into the current checkout:
@@ -91,6 +92,18 @@ The script supports:
 Successful install and skip paths verify that exactly one install target contains the locked common skills and that each installed skill matches `skills-lock.json`.
 Project installs add local Git exclude entries for only the locked common-skill directories so unrelated project skills in `.agents/skills` remain visible to Git.
 Global installs are shared across client repositories. A second repo pinned to the same lock verifies and succeeds without unnecessarily reinstalling; a repo pinned to a different lock fails with a version-mismatch error instead of overwriting the shared global install.
+## Update lock script
+`update_common_skills_lock` non-interactively regenerates an existing `skills-lock.json` from the default branch of `warpdotdev/common-skills` without installing skills into the target repository.
+It generates a candidate in a temporary Git repository, then copies back only a changed `skills-lock.json`. Generator failures and missing candidate output fail the command instead of retaining the existing lock.
+Run it from a consuming repository:
+```sh
+/path/to/common-skills/scripts/update_common_skills_lock --repo-root /path/to/consumer
+```
+The downstream lockfile update workflow uses this command before opening lockfile-only pull requests.
+## Downstream lockfile workflow
+`.github/workflows/update-downstream-skill-locks.yml` runs after every push to `main` and opens lockfile-only pull requests against `warpdotdev/warp` and `warpdotdev/warp-server` when their locks change.
+Each pull request requests the author of the originating common-skills pull request when possible and enables squash auto-merge. Direct pushes and authors who cannot review a target repository do not prevent pull request creation.
+The workflow requires a dedicated GitHub App installed on both downstream repositories with contents and pull-request write access. Configure its App ID as the `COMMON_SKILLS_SYNC_APP_ID` Actions variable and its private key as the `COMMON_SKILLS_SYNC_APP_PRIVATE_KEY` Actions secret in `common-skills`.
 ## Remove script
 `remove_common_skills` removes common agent skills listed in `skills-lock.json`.
 The script supports:

--- a/scripts/update_common_skills_lock
+++ b/scripts/update_common_skills_lock
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+REPO_ROOT="$(pwd)"
+LOCK_FILE=""
+TEMP_DIR=""
+SKILLS_CLI_VERSION="1.5.6"
+COMMON_SKILLS_SOURCE="warpdotdev/common-skills"
+SKILLS_CLI_AGENT="warp"
+COMMON_SKILL_SELECTOR="*"
+
+usage() {
+  cat <<EOF
+Usage: scripts/update_common_skills_lock [options]
+
+Regenerate an existing skills-lock.json from warpdotdev/common-skills.
+
+Options:
+  --repo-root <path>   Repository containing skills-lock.json.
+  -h, --help           Show this help message.
+EOF
+}
+
+cleanup() {
+  if [[ -n "${TEMP_DIR}" ]]; then
+    rm -rf "${TEMP_DIR}"
+  fi
+}
+
+validate_required_commands() {
+  local missing=0
+  local tool=""
+
+  for tool in "$@"; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+      echo "error: required command '${tool}' is not installed or not on PATH." >&2
+      missing=1
+    fi
+  done
+
+  if [[ "${missing}" -eq 1 ]]; then
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --repo-root requires a path." >&2
+        usage >&2
+        exit 1
+      fi
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unrecognized argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+validate_required_commands git node npm npx
+
+if ! REPO_ROOT="$(cd "${REPO_ROOT}" && pwd)"; then
+  echo "error: repository root does not exist: ${REPO_ROOT}" >&2
+  exit 1
+fi
+
+LOCK_FILE="${REPO_ROOT}/skills-lock.json"
+if [[ ! -f "${LOCK_FILE}" ]]; then
+  echo "error: missing skills lock file: ${LOCK_FILE}" >&2
+  exit 1
+fi
+
+trap cleanup EXIT
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/common-skills-lock.XXXXXX")"
+cp "${LOCK_FILE}" "${TEMP_DIR}/skills-lock.json"
+git -C "${TEMP_DIR}" init --quiet
+
+if ! (
+  cd "${TEMP_DIR}"
+  npx --yes "skills@${SKILLS_CLI_VERSION}" add "${COMMON_SKILLS_SOURCE}" -a "${SKILLS_CLI_AGENT}" -s "${COMMON_SKILL_SELECTOR}" -y --copy
+) < /dev/null; then
+  echo "error: failed to generate an updated skills-lock.json from ${COMMON_SKILLS_SOURCE}." >&2
+  exit 1
+fi
+
+if [[ ! -f "${TEMP_DIR}/skills-lock.json" ]]; then
+  echo "error: common skills update did not produce a candidate skills-lock.json." >&2
+  exit 1
+fi
+
+if cmp -s "${LOCK_FILE}" "${TEMP_DIR}/skills-lock.json"; then
+  echo "skills-lock.json is already up to date."
+  exit 0
+fi
+
+cp "${TEMP_DIR}/skills-lock.json" "${LOCK_FILE}"
+echo "Updated ${LOCK_FILE}."


### PR DESCRIPTION
## Description

Automates propagation of common-skills changes to the downstream lockfiles that engineers consume. On every push to `main`, the workflow regenerates the lockfiles in `warpdotdev/warp` and `warpdotdev/warp-server`, opens ready-for-review PRs, requests the originating common-skills PR author when possible, and enables squash auto-merge.

Adds a lock-only helper so CI can refresh hashes without installing skills into the target checkout. Downstream writes use the dedicated, repository-scoped common-skills-sync GitHub App; its installation and the required Actions variable and secret are configured.

## Testing

- `bash -n scripts/update_common_skills_lock`
- `shellcheck scripts/update_common_skills_lock`
- `actionlint .github/workflows/update-downstream-skill-locks.yml`
- `git diff --check`
- Ran the updater twice against an isolated copy of a downstream lockfile; the first run generated all 19 current skills without Git refs, and the second run was a no-op.
- Verified source PR lookup resolves PR #28 to `vorporeal`.

Co-Authored-By: Oz <oz-agent@warp.dev>