### PR TITLE
Make some improvements to spec-related skills.

### DIFF
--- a/.agents/skills/check-impl-against-spec/SKILL.md
+++ b/.agents/skills/check-impl-against-spec/SKILL.md
@@ -46,5 +46,5 @@ Determine whether the implementation in the checked-out PR materially matches th
 
 - Do not require literal one-to-one implementation of the spec when the PR achieves the same outcome safely.
 - Do not speculate about spec details that are not actually present in `spec_context.md`.
-- Do not discount, relocate, or reclassify a commitment based on which source document contains it.
+- Evaluate each commitment on its substance regardless of which source document contains it.
 - Do not post to GitHub directly.

--- a/.agents/skills/check-impl-against-spec/SKILL.md
+++ b/.agents/skills/check-impl-against-spec/SKILL.md
@@ -13,25 +13,25 @@ Determine whether the implementation in the checked-out PR materially matches th
 
 ## Inputs
 
-- `spec_context.md` contains the spec context to compare against. It may include both product spec content (intended behavior, acceptance criteria) and tech spec content (implementation details, file changes).
+- `spec_context.md` contains the approved spec context to compare against. It may combine behavior, design, constraints, validation, migrations, rollout, and non-goals from any relevant specs.
 - `pr_diff.txt` contains the annotated diff for the PR.
 - `pr_description.md` may contain additional scope or rationale.
 - The working tree contains the PR branch contents.
 
 ## Process
 
-1. Read `spec_context.md` and extract the concrete commitments it makes:
-   - required behaviors (from the product spec)
-   - required files or subsystems to change (from the tech spec)
-   - stated constraints
-   - required follow-up steps, validation, or migrations
+1. Read `spec_context.md` and extract the concrete commitments it makes, regardless of which source document contains them:
+   - required behaviors
+   - design and implementation constraints
+   - required validation, migrations, rollout, or compatibility steps
+   - non-goals and intentionally deferred work
 2. Compare those commitments against the actual implementation in `pr_diff.txt` and the checked-out files.
 3. Treat small implementation-level adjustments as acceptable when they preserve the spec's intent. Do not flag harmless differences in naming, structure, or low-level technique.
 4. Flag a mismatch only when it is material, such as:
-   - required behavior in the product spec is missing
-   - the implementation contradicts a spec decision
+   - required behavior from the approved spec context is missing
+   - the implementation contradicts an approved decision or constraint
    - the change introduces significant unplanned scope
-   - a required validation, migration, or compatibility step from the tech spec is absent
+   - a required validation, migration, rollout, or compatibility step is absent
 
 ## Outputs
 
@@ -46,4 +46,5 @@ Determine whether the implementation in the checked-out PR materially matches th
 
 - Do not require literal one-to-one implementation of the spec when the PR achieves the same outcome safely.
 - Do not speculate about spec details that are not actually present in `spec_context.md`.
+- Do not discount, relocate, or reclassify a commitment based on which source document contains it.
 - Do not post to GitHub directly.

--- a/.agents/skills/implement-specs/SKILL.md
+++ b/.agents/skills/implement-specs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement-specs
-description: Implements approved work from whichever valuable specs exist, including PRODUCT.md, TECH.md, or both. Keeps applicable specs and code aligned as implementation evolves without creating or preserving redundant documents.
+description: Implements approved work from whichever specs exist, including PRODUCT.md, TECH.md, or both. Keeps applicable specs and code aligned as implementation evolves without silently creating, deleting, or reclassifying approved documents.
 ---
 
 # implement-specs
@@ -11,7 +11,7 @@ Implement approved work from `PRODUCT.md`, `TECH.md`, or both.
 
 Use this skill after the warranted specs are approved. The goal is to build the change described by the available specs while keeping those checked-in specs and the implementation aligned as the work evolves.
 
-Approved specs should live directly under a ticket-named directory in `specs/`, for example `specs/APP-1234/PRODUCT.md`, `specs/APP-1234/TECH.md`, or both.
+Approved specs should live directly under `specs/<id>/`, for example `specs/APP-1234/PRODUCT.md`, `specs/gh-4567/TECH.md`, or both.
 
 In many cases, the implementation should be pushed in the same PR as the applicable specs. As the engineer iterates, changes to those specs and the code should all be pushed in that same PR so review stays anchored to the change that will actually ship.
 
@@ -19,9 +19,10 @@ In many cases, the implementation should be pushed in the same PR as the applica
 
 Before using this skill:
 
-- confirm which of `PRODUCT.md` and `TECH.md` exist and that each still adds independent value
+- confirm which of `PRODUCT.md` and `TECH.md` make up the approved artifact set
 - confirm that at least one approved spec exists
 - confirm that the relevant specs have been reviewed and approved enough to start implementation
+- treat the approved artifact set as the starting contract; flag concerns about its continued value without deleting or reclassifying documents unilaterally
 
 ## Workflow
 
@@ -29,8 +30,8 @@ Before using this skill:
 
 Treat whichever sources exist as authoritative for their scope:
 
-- `PRODUCT.md` as the source of truth for meaningful user-facing or public-contract behavior
-- `TECH.md` as the source of truth for architecture, sequencing, implementation shape, validation, and standalone behavioral guarantees when there is no product spec
+- `PRODUCT.md` as the source of truth for meaningful user-facing, public-contract, or deliberately stable cross-team consumer behavior
+- `TECH.md` as the source of truth for architecture, sequencing, implementation shape, validation, and the `Technical safety and preservation guarantees` section, whether or not a product spec exists
 
 Make sure you understand the expected behavior, constraints, risks, and validation plan before writing code.
 
@@ -49,23 +50,24 @@ Break the work into concrete implementation steps, then implement the change aga
 
 During implementation:
 
-- keep behavior aligned with `PRODUCT.md` when it exists, otherwise with the behavioral guarantees in `TECH.md`
+- keep meaningful consumer behavior aligned with `PRODUCT.md` when it exists, otherwise with the outcome-preservation boundary in `TECH.md`
 - keep architecture and sequencing aligned with `TECH.md` when it exists
 - add or update tests and verification artifacts as the work lands
+- for PRODUCT-only work, keep a lightweight validation map from important behavior to concrete verification in the implementation plan or PR
 
 Use the same PR for the specs and implementation when practical so the full evolution of the change is reviewable in one place.
 
 ### 4. Update specs as the implementation evolves
 
-If implementation reveals that the intended behavior or design should change, update the checked-in specs rather than letting them go stale.
+If implementation reveals that approved behavior or design should materially change, surface the change for re-review before updating the checked-in specs. Apply routine edits that only keep the approved intent current rather than letting the specs go stale.
 
 In particular:
 
-- update `PRODUCT.md`, when it exists, when meaningful user-facing behavior, UX, or public-contract decisions change
-- update `TECH.md`, when it exists, when architecture, sequencing, module boundaries, behavioral guarantees, or validation strategy change
+- update `PRODUCT.md`, when it exists, when meaningful user-facing behavior, UX, public-contract, or deliberately stable cross-team contract decisions change
+- update `TECH.md`, when it exists, when architecture, sequencing, module boundaries, the `Technical safety and preservation guarantees` section, or validation strategy changes
 - keep those updates in the same PR as the corresponding code changes
 
-If a spec stops adding independent value as the design evolves, consolidate any durable guarantees into the remaining source of truth and remove the redundant document rather than maintaining synchronized copies.
+If a spec stops adding independent value as the design evolves, propose consolidating any durable guarantees into the remaining source of truth. Get explicit confirmation from the user or accountable spec owner before deleting or reclassifying an approved document.
 
 The PR should describe the change that actually ships, not just the initial draft of the specs.
 
@@ -78,9 +80,12 @@ Prefer:
 - unit tests and regression coverage that follow the repository's local testing conventions
 - integration or end-to-end tests for important user flows
 
+Map each important technical guarantee and relevant product behavior to at least one concrete verification step without creating an exhaustive duplicate matrix.
+
 ## Best Practices
 
 - Keep specs and code synchronized throughout implementation.
+- Do not silently re-litigate, delete, or reclassify the approved artifact set.
 - Prefer updating the spec immediately when decisions change rather than batching spec cleanup until the end.
 - Use optional tracking documents only when they add real value for a complex feature.
 - Keep the same PR coherent: spec updates, code changes, tests, and optional tracking docs should all support the same change narrative.

--- a/.agents/skills/implement-specs/SKILL.md
+++ b/.agents/skills/implement-specs/SKILL.md
@@ -20,7 +20,10 @@ In many cases, the implementation should be pushed in the same PR as the applica
 Before using this skill:
 
 - identify and read every approved spec relevant to the change
-- confirm that at least one approved spec exists and has been reviewed and approved enough to start implementation
+- confirm that at least one approved spec exists and has explicit approval to start implementation
+- confirm that every implementation-blocking open question has been resolved or explicitly deferred by the user or another explicitly identified human approver
+
+If the approval or disposition of an implementation-blocking question is not evident from the current context, ask before writing code.
 
 ## Workflow
 
@@ -50,7 +53,9 @@ Use the same PR for the specs and implementation when practical so the full evol
 
 ### 4. Update specs as the implementation evolves
 
-If implementation reveals that approved behavior or design should materially change, surface the change for re-review before updating the checked-in specs. Apply routine edits that only keep the approved intent current rather than letting the specs go stale.
+A material change alters an approved behavior, guarantee, architectural decision, scope boundary, risk or rollout assumption, or validation expectation. A routine edit records factual implementation detail or clarifies wording while preserving every approved decision.
+
+When implementation reveals a proposed material change, describe its impact and get explicit approval from the user or another explicitly identified human approver before persisting it in the checked-in specs or acting on it in the implementation. Ask when the distinction between material and routine is unclear. Apply routine edits that keep the approved intent current.
 
 In particular:
 
@@ -74,7 +79,7 @@ Map each important approved commitment to at least one concrete verification ste
 
 - Keep specs and code synchronized throughout implementation.
 - Treat the approved artifact set as settled input during implementation and surface material conflicts for review.
-- Prefer updating the spec immediately when decisions change rather than batching spec cleanup until the end.
+- Record approved material decisions in the applicable specs promptly.
 - Use optional tracking documents only when they add real value for a complex feature.
 - Keep the same PR coherent: spec updates, code changes, tests, and optional tracking docs should all support the same change narrative.
 

--- a/.agents/skills/implement-specs/SKILL.md
+++ b/.agents/skills/implement-specs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement-specs
-description: Implements approved work from whichever specs exist, including PRODUCT.md, TECH.md, or both. Keeps applicable specs and code aligned as implementation evolves without silently creating, deleting, or reclassifying approved documents.
+description: Implements approved PRODUCT.md and/or TECH.md specs, keeping applicable specs and code aligned as implementation evolves. Use after the specs are approved and the next step is implementation.
 ---
 
 # implement-specs
@@ -28,12 +28,7 @@ Before using this skill:
 
 ### 1. Read the approved specs first
 
-Treat whichever sources exist as authoritative for their scope:
-
-- `PRODUCT.md` as the source of truth for meaningful user-facing, public-contract, or deliberately stable cross-team consumer behavior
-- `TECH.md` as the source of truth for architecture, sequencing, implementation shape, validation, and the `Technical safety and preservation guarantees` section, whether or not a product spec exists
-
-Make sure you understand the expected behavior, constraints, risks, and validation plan before writing code.
+Treat every approved spec as authoritative input to the intended change. Read all available specs before writing code and make sure you understand the expected behavior, design, constraints, risks, and validation plan.
 
 ### 2. Offer optional implementation aids for large features
 
@@ -50,8 +45,7 @@ Break the work into concrete implementation steps, then implement the change aga
 
 During implementation:
 
-- keep meaningful consumer behavior aligned with `PRODUCT.md` when it exists, otherwise with the outcome-preservation boundary in `TECH.md`
-- keep architecture and sequencing aligned with `TECH.md` when it exists
+- keep behavior, design, and implementation aligned with all approved specs
 - add or update tests and verification artifacts as the work lands
 - for PRODUCT-only work, keep a lightweight validation map from important behavior to concrete verification in the implementation plan or PR
 
@@ -63,8 +57,7 @@ If implementation reveals that approved behavior or design should materially cha
 
 In particular:
 
-- update `PRODUCT.md`, when it exists, when meaningful user-facing behavior, UX, public-contract, or deliberately stable cross-team contract decisions change
-- update `TECH.md`, when it exists, when architecture, sequencing, module boundaries, the `Technical safety and preservation guarantees` section, or validation strategy changes
+- update whichever approved specs describe the changed behavior, design, constraints, risks, or validation
 - keep those updates in the same PR as the corresponding code changes
 
 If a spec stops adding independent value as the design evolves, propose consolidating any durable guarantees into the remaining source of truth. Get explicit confirmation from the user or accountable spec owner before deleting or reclassifying an approved document.

--- a/.agents/skills/implement-specs/SKILL.md
+++ b/.agents/skills/implement-specs/SKILL.md
@@ -9,7 +9,7 @@ Implement approved work from `PRODUCT.md`, `TECH.md`, or both.
 
 ## Overview
 
-Use this skill after the warranted specs are approved. The goal is to build the change described by the available specs while keeping those checked-in specs and the implementation aligned as the work evolves.
+Use this skill after the applicable specs are approved. The goal is to build the change described by the available specs while keeping those checked-in specs and the implementation aligned as the work evolves.
 
 Approved specs should live directly under `specs/<id>/`, for example `specs/APP-1234/PRODUCT.md`, `specs/gh-4567/TECH.md`, or both.
 
@@ -19,10 +19,8 @@ In many cases, the implementation should be pushed in the same PR as the applica
 
 Before using this skill:
 
-- confirm which of `PRODUCT.md` and `TECH.md` make up the approved artifact set
-- confirm that at least one approved spec exists
-- confirm that the relevant specs have been reviewed and approved enough to start implementation
-- treat the approved artifact set as the starting contract; flag concerns about its continued value without deleting or reclassifying documents unilaterally
+- identify and read every approved spec relevant to the change
+- confirm that at least one approved spec exists and has been reviewed and approved enough to start implementation
 
 ## Workflow
 
@@ -47,7 +45,6 @@ During implementation:
 
 - keep behavior, design, and implementation aligned with all approved specs
 - add or update tests and verification artifacts as the work lands
-- for PRODUCT-only work, keep a lightweight validation map from important behavior to concrete verification in the implementation plan or PR
 
 Use the same PR for the specs and implementation when practical so the full evolution of the change is reviewable in one place.
 
@@ -60,8 +57,6 @@ In particular:
 - update whichever approved specs describe the changed behavior, design, constraints, risks, or validation
 - keep those updates in the same PR as the corresponding code changes
 
-If a spec stops adding independent value as the design evolves, propose consolidating any durable guarantees into the remaining source of truth. Get explicit confirmation from the user or accountable spec owner before deleting or reclassifying an approved document.
-
 The PR should describe the change that actually ships, not just the initial draft of the specs.
 
 ### 5. Verify against the specs
@@ -73,12 +68,12 @@ Prefer:
 - unit tests and regression coverage that follow the repository's local testing conventions
 - integration or end-to-end tests for important user flows
 
-Map each important technical guarantee and relevant product behavior to at least one concrete verification step without creating an exhaustive duplicate matrix.
+Map each important approved commitment to at least one concrete verification step without creating an exhaustive duplicate matrix.
 
 ## Best Practices
 
 - Keep specs and code synchronized throughout implementation.
-- Do not silently re-litigate, delete, or reclassify the approved artifact set.
+- Do not re-litigate, delete, or reclassify the approved artifact set during implementation; surface material conflicts for review.
 - Prefer updating the spec immediately when decisions change rather than batching spec cleanup until the end.
 - Use optional tracking documents only when they add real value for a complex feature.
 - Keep the same PR coherent: spec updates, code changes, tests, and optional tracking docs should all support the same change narrative.

--- a/.agents/skills/implement-specs/SKILL.md
+++ b/.agents/skills/implement-specs/SKILL.md
@@ -73,7 +73,7 @@ Map each important approved commitment to at least one concrete verification ste
 ## Best Practices
 
 - Keep specs and code synchronized throughout implementation.
-- Do not re-litigate, delete, or reclassify the approved artifact set during implementation; surface material conflicts for review.
+- Treat the approved artifact set as settled input during implementation and surface material conflicts for review.
 - Prefer updating the spec immediately when decisions change rather than batching spec cleanup until the end.
 - Use optional tracking documents only when they add real value for a complex feature.
 - Keep the same PR coherent: spec updates, code changes, tests, and optional tracking docs should all support the same change narrative.

--- a/.agents/skills/implement-specs/SKILL.md
+++ b/.agents/skills/implement-specs/SKILL.md
@@ -1,36 +1,36 @@
 ---
 name: implement-specs
-description: Implement an approved feature from PRODUCT.md and TECH.md, keeping specs and code aligned in the same PR as implementation evolves. Use after the product and tech specs are approved and the next step is building the feature.
+description: Implements approved work from whichever valuable specs exist, including PRODUCT.md, TECH.md, or both. Keeps applicable specs and code aligned as implementation evolves without creating or preserving redundant documents.
 ---
 
 # implement-specs
 
-Implement an approved feature from `PRODUCT.md` and `TECH.md`.
+Implement approved work from `PRODUCT.md`, `TECH.md`, or both.
 
 ## Overview
 
-Use this skill after the product and tech specs are approved. The goal is to build the feature described by the specs while keeping the checked-in specs and the implementation aligned as the work evolves.
+Use this skill after the warranted specs are approved. The goal is to build the change described by the available specs while keeping those checked-in specs and the implementation aligned as the work evolves.
 
-Approved specs should live directly under a ticket-named directory in `specs/`, for example `specs/APP-1234/PRODUCT.md` and `specs/APP-1234/TECH.md`.
+Approved specs should live directly under a ticket-named directory in `specs/`, for example `specs/APP-1234/PRODUCT.md`, `specs/APP-1234/TECH.md`, or both.
 
-In many cases, the implementation should be pushed in the same PR as the product and tech specs. As the engineer iterates, changes to `PRODUCT.md`, `TECH.md`, and the code should all be pushed in that same PR so review stays anchored to the feature that will actually ship.
+In many cases, the implementation should be pushed in the same PR as the applicable specs. As the engineer iterates, changes to those specs and the code should all be pushed in that same PR so review stays anchored to the change that will actually ship.
 
 ## Prerequisites
 
 Before using this skill:
 
-- confirm that `PRODUCT.md` exists
-- confirm that `TECH.md` exists when the feature warranted one
+- confirm which of `PRODUCT.md` and `TECH.md` exist and that each still adds independent value
+- confirm that at least one approved spec exists
 - confirm that the relevant specs have been reviewed and approved enough to start implementation
 
 ## Workflow
 
 ### 1. Read the approved specs first
 
-Treat:
+Treat whichever sources exist as authoritative for their scope:
 
-- `PRODUCT.md` as the source of truth for user-facing behavior
-- `TECH.md` as the source of truth for architecture, sequencing, and implementation shape
+- `PRODUCT.md` as the source of truth for meaningful user-facing or public-contract behavior
+- `TECH.md` as the source of truth for architecture, sequencing, implementation shape, validation, and standalone behavioral guarantees when there is no product spec
 
 Make sure you understand the expected behavior, constraints, risks, and validation plan before writing code.
 
@@ -45,15 +45,15 @@ These are optional aids, not required deliverables. Offer them when they would r
 
 ### 3. Plan and implement against the specs
 
-Break the work into concrete implementation steps, then implement the feature against the approved specs.
+Break the work into concrete implementation steps, then implement the change against the approved specs.
 
 During implementation:
 
-- keep behavior aligned with `PRODUCT.md`
-- keep architecture and sequencing aligned with `TECH.md`
+- keep behavior aligned with `PRODUCT.md` when it exists, otherwise with the behavioral guarantees in `TECH.md`
+- keep architecture and sequencing aligned with `TECH.md` when it exists
 - add or update tests and verification artifacts as the work lands
 
-Use the same PR for the specs and implementation when practical so the full feature evolution is reviewable in one place.
+Use the same PR for the specs and implementation when practical so the full evolution of the change is reviewable in one place.
 
 ### 4. Update specs as the implementation evolves
 
@@ -61,11 +61,13 @@ If implementation reveals that the intended behavior or design should change, up
 
 In particular:
 
-- update `PRODUCT.md` when user-facing behavior, UX, edge cases, or success criteria change
-- update `TECH.md` when architecture, sequencing, module boundaries, or validation strategy change
+- update `PRODUCT.md`, when it exists, when meaningful user-facing behavior, UX, or public-contract decisions change
+- update `TECH.md`, when it exists, when architecture, sequencing, module boundaries, behavioral guarantees, or validation strategy change
 - keep those updates in the same PR as the corresponding code changes
 
-The PR should describe the feature that actually ships, not just the initial draft of the specs.
+If a spec stops adding independent value as the design evolves, consolidate any durable guarantees into the remaining source of truth and remove the redundant document rather than maintaining synchronized copies.
+
+The PR should describe the change that actually ships, not just the initial draft of the specs.
 
 ### 5. Verify against the specs
 
@@ -81,7 +83,7 @@ Prefer:
 - Keep specs and code synchronized throughout implementation.
 - Prefer updating the spec immediately when decisions change rather than batching spec cleanup until the end.
 - Use optional tracking documents only when they add real value for a complex feature.
-- Keep the same PR coherent: spec updates, code changes, tests, and optional tracking docs should all support the same feature narrative.
+- Keep the same PR coherent: spec updates, code changes, tests, and optional tracking docs should all support the same change narrative.
 
 ## Related Skills
 

--- a/.agents/skills/spec-driven-implementation/SKILL.md
+++ b/.agents/skills/spec-driven-implementation/SKILL.md
@@ -73,6 +73,8 @@ Evaluate the size, ambiguity, and risk of the work. If specs will not meaningful
 
 Do not assume `PRODUCT.md` comes first or that both documents are required. Choose no spec, `PRODUCT.md` only, `TECH.md` only, or both using the independent-value and semantic-preservation tests above.
 
+Present the chosen artifact set and a brief rationale to the user or another explicitly identified human approver, and get explicit approval before proceeding with the selected path.
+
 Treat the approved artifact set as part of the reviewed plan. Route any later artifact-selection review back through this workflow while implementation consumes the settled artifact set.
 
 ### 3. Write and approve the selected specs
@@ -91,6 +93,8 @@ Use the `write-tech-spec` skill when the selected artifact set includes `TECH.md
 
 It is acceptable to write the tech spec after an e2e prototype if that leads to a more accurate implementation plan. Do not force a premature tech spec when the implementation details are still too uncertain.
 
+After the selected specs are drafted, present the material decisions, important tradeoffs, and unresolved questions. Ask the user or another explicitly identified human approver to resolve or explicitly defer every question that would affect implementation, then get explicit approval for the specs before implementation begins.
+
 ### 4. Implement approved specs
 
 After the warranted specs are approved, use the `implement-specs` skill to build from whichever approved documents exist.
@@ -108,7 +112,9 @@ These are optional aids, not required outputs.
 
 ### 5. Keep specs current during implementation
 
-If implementation reveals that approved behavior or design should materially change, surface the change for re-review before updating the spec. Apply routine edits that only keep the approved intent current rather than leaving the spec stale.
+A material change alters an approved behavior, guarantee, architectural decision, scope boundary, risk or rollout assumption, or validation expectation. A routine edit records factual implementation detail or clarifies wording while preserving every approved decision.
+
+When implementation reveals a proposed material change, describe its impact and get explicit approval from the user or another explicitly identified human approver before persisting it in the specs or acting on it in the implementation. Ask when the distinction between material and routine is unclear. Apply routine edits that keep the approved intent current.
 
 Update `PRODUCT.md`, when it exists, when:
 
@@ -125,7 +131,7 @@ Update `TECH.md`, when it exists, when:
 
 The checked-in specs should describe the change that actually ships, not just the initial intent. Keep those spec updates in the same PR as the related code changes whenever practical.
 
-If evolving design calls the approved artifact set into question, return to the artifact-selection step. Explain the proposed artifact set, show how every durable guarantee remains represented, and get explicit confirmation from the user or accountable spec owner before changing the approved artifact set.
+If evolving design calls the approved artifact set into question, return to the artifact-selection step. Explain the proposed artifact set, show how every durable guarantee remains represented, and get explicit confirmation from the user or another explicitly identified human approver before changing the approved artifact set.
 
 ### 6. Verify behavior against the spec
 

--- a/.agents/skills/spec-driven-implementation/SKILL.md
+++ b/.agents/skills/spec-driven-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-driven-implementation
-description: Drives a pragmatic spec-first workflow by choosing among no spec, PRODUCT.md only, standalone TECH.md with behavioral guarantees, or both. Use when starting significant feature or hardening work, planning agent-driven implementation, or deciding which specs should be checked into source control.
+description: Drives a pragmatic spec-first workflow by choosing among no spec, PRODUCT.md only, standalone TECH.md with technical safety and preservation guarantees, or both. Use when starting significant feature or hardening work, planning agent-driven implementation, or deciding which specs should be checked into source control.
 ---
 
 # spec-driven-implementation
@@ -13,17 +13,18 @@ Use this skill for significant work where a written spec will improve implementa
 
 Specs may live in:
 
-- `specs/<linear-ticket-number>/PRODUCT.md`
-- `specs/<linear-ticket-number>/TECH.md`
+- `specs/<id>/PRODUCT.md`
+- `specs/<id>/TECH.md`
 
-For example:
+Use a Linear ticket number, `gh-`-prefixed GitHub issue id, or short kebab-case feature name as `<id>`. For example:
 
 - `specs/APP-1234/PRODUCT.md`
-- `specs/APP-1234/TECH.md`
+- `specs/gh-4567/TECH.md`
+- `specs/vertical-tabs-hover-sidecar/TECH.md`
 
-`specs/` should contain only ticket-named directories as direct children. Do not create engineer-named subdirectories or feature-slug directories there.
+`specs/` should contain only id-named directories as direct children. Do not create engineer-named subdirectories there.
 
-Use a relevant Linear issue when one already exists. Only create one when the user explicitly asks; in that case use the Linear MCP tools directly:
+Use a relevant Linear or GitHub issue when one already exists. If none exists, ask the user for a short feature name. Only create an issue when the user explicitly asks; use the Linear MCP tools or `gh` CLI respectively. For Linear:
 
 - `list_teams` to find the appropriate team
 - `list_issue_labels` to inspect the expected labels/tags
@@ -33,7 +34,7 @@ If the correct team or labels are not obvious from the request and surrounding c
 
 Specs should largely be written by agents, not by hand, and should be checked into source control when their ongoing review value exceeds the cost of keeping them current with the code.
 
-## When specs are required
+## When specs add value
 
 Strongly prefer specs when the change is substantial, such as:
 
@@ -54,11 +55,13 @@ For pure UI changes, the product spec is often useful while the tech spec may be
 Choose the smallest document set that adds independent value:
 
 - **No spec** — Small, clear work that is better captured by the issue, code, and tests.
-- **`PRODUCT.md` only** — Meaningful user-facing or public-contract behavior is ambiguous, but implementation is straightforward.
-- **`TECH.md` only** — Internal hardening, a bug fix, refactor, migration, lifecycle/concurrency work, or other technically complex change that preserves existing product semantics. Include a concise `Behavioral guarantees` section.
+- **`PRODUCT.md` only** — Meaningful user-facing, public-contract, or deliberately stable cross-team consumer behavior is ambiguous, but implementation is straightforward.
+- **`TECH.md` only** — Internal hardening, a bug fix, refactor, migration, lifecycle/concurrency work, or another technically complex change whose relevant consumer semantics remain unchanged. Include concise `Technical safety and preservation guarantees`.
 - **Both** — Product behavior and technical design each contain meaningful, independently reviewable decisions.
 
 Technical size or cross-cutting scope alone is not a reason to create `PRODUCT.md`.
+
+Before choosing an artifact set without `PRODUCT.md`, state in one sentence whether user-visible, public, and deliberately stable cross-team consumer semantics — including failure and recovery behavior — change. If they change, explain briefly why the independent-value test still does not warrant a product spec; small, obvious changes may still need no spec. Task labels such as "bug fix," "refactor," and "hardening" are not evidence that semantics remain unchanged.
 
 ## Workflow
 
@@ -66,32 +69,25 @@ Technical size or cross-cutting scope alone is not a reason to create `PRODUCT.m
 
 Evaluate the size, ambiguity, and risk of the work. If specs will not meaningfully improve execution or review, skip them and focus on verification instead.
 
-### 2. Choose and write only the warranted specs
+### 2. Choose the artifact set
 
-Do not assume `PRODUCT.md` comes first or that both documents are required.
+Do not assume `PRODUCT.md` comes first or that both documents are required. Choose no spec, `PRODUCT.md` only, `TECH.md` only, or both using the independent-value and semantic-preservation tests above.
 
-Use the `write-product-spec` skill only when the product behavior has independent review value. The product spec should define:
+Treat the approved artifact set as part of the reviewed plan. Implementation may flag that an approved document has become redundant, but must not delete or reclassify it without explicit confirmation from the user or accountable spec owner.
+
+### 3. Write and approve the selected specs
+
+Use the `write-product-spec` skill only when consumer behavior has independent review value. The product spec should define:
 
 - what problem is being solved
-- the desired user experience
-- meaningful product invariants and user-visible edge cases
+- the desired user experience or consumer contract
+- meaningful product invariants and consumer-visible edge cases
 
 If the work has UI or interaction design, ask for a Figma mock if one exists. If there is no mock, continue but call that out explicitly in the product spec.
 
-Reference the Linear issue in the spec when one exists. Because specs live under `specs/<linear-ticket-number>/...`, this should usually be straightforward.
+Reference the Linear or GitHub issue in the spec when one exists.
 
-For technically complex work that preserves existing product semantics, skip `PRODUCT.md` and use a standalone `TECH.md` with concise behavioral guarantees.
-
-### 3. Write the tech spec when warranted
-
-Use the `write-tech-spec` skill for substantial or ambiguous implementation work.
-
-Prefer a tech spec when:
-
-- the implementation spans multiple subsystems
-- architecture or extensibility matters
-- there are meaningful tradeoffs to document
-- reviewers will benefit more from reviewing the plan than the raw code
+Use the `write-tech-spec` skill when the selected artifact set includes `TECH.md`. Prefer a tech spec when the implementation spans multiple subsystems, architecture or extensibility matters, there are meaningful tradeoffs to document, or reviewers will benefit more from reviewing the plan than the raw code.
 
 It is acceptable to write the tech spec after an e2e prototype if that leads to a more accurate implementation plan. Do not force a premature tech spec when the implementation details are still too uncertain.
 
@@ -100,6 +96,8 @@ It is acceptable to write the tech spec after an e2e prototype if that leads to 
 After the warranted specs are approved, use the `implement-specs` skill to build from whichever approved documents exist.
 
 The implementation can often be pushed in the same PR as the specs. As the engineer iterates, keep the applicable specs, code changes, and tests in that same PR so the review reflects the change that will actually ship.
+
+For PRODUCT-only work, keep a lightweight map from important product behavior to concrete verification in the implementation plan or PR rather than adding a testing section to `PRODUCT.md`.
 
 For large features, the implementer may optionally offer:
 
@@ -110,7 +108,7 @@ These are optional aids, not required outputs.
 
 ### 5. Keep specs current during implementation
 
-If implementation changes from the spec, update the spec rather than leaving it stale.
+If implementation reveals that approved behavior or design should materially change, surface the change for re-review before updating the spec. Apply routine edits that only keep the approved intent current rather than leaving the spec stale.
 
 Update `PRODUCT.md`, when it exists, when:
 
@@ -127,11 +125,11 @@ Update `TECH.md`, when it exists, when:
 
 The checked-in specs should describe the change that actually ships, not just the initial intent. Keep those spec updates in the same PR as the related code changes whenever practical.
 
-If a spec stops adding independent value as the design evolves, consolidate any durable guarantees into the remaining source of truth and remove the redundant document rather than maintaining two synchronized copies.
+If a spec stops adding independent value as the design evolves, propose consolidating any durable guarantees into the remaining source of truth. Get explicit confirmation from the user or accountable spec owner before deleting or reclassifying an approved spec.
 
 ### 6. Verify behavior against the spec
 
-Before considering the work complete, make sure verification maps back to the applicable specs. Prefer tests and artifacts that validate the product behavior or standalone behavioral guarantees directly:
+Before considering the work complete, make sure verification maps back to the applicable specs and guarantees, or to the lightweight validation map for PRODUCT-only work. Prefer tests and artifacts that validate the product behavior or technical safety and preservation guarantees directly:
 
 - unit tests and regression coverage that follow the repository's local testing conventions
 - integration tests for critical user flows
@@ -144,7 +142,7 @@ Before considering the work complete, make sure verification maps back to the ap
 - Write specs to improve input quality for agents, not as ceremony.
 - Choose document types based on independent review value, not implementation size alone.
 - Keep product specs behavior-oriented and implementation-light.
-- Keep tech specs implementation-oriented and grounded in current codebase patterns; use concise behavioral guarantees when no product spec is warranted.
+- Keep tech specs implementation-oriented and grounded in current codebase patterns; use concise technical safety and preservation guarantees when they add independent value.
 - When a spec references relevant code chunks, include the inspected commit SHA in the file reference when possible and link the reference to the exact GitHub `blob/<sha>/...#Lx-Ly` lines.
 - Use review time to validate specs and behavior, not to over-index on code style nits.
 

--- a/.agents/skills/spec-driven-implementation/SKILL.md
+++ b/.agents/skills/spec-driven-implementation/SKILL.md
@@ -73,7 +73,7 @@ Evaluate the size, ambiguity, and risk of the work. If specs will not meaningful
 
 Do not assume `PRODUCT.md` comes first or that both documents are required. Choose no spec, `PRODUCT.md` only, `TECH.md` only, or both using the independent-value and semantic-preservation tests above.
 
-Treat the approved artifact set as part of the reviewed plan. Implementation may flag that an approved document has become redundant, but must not delete or reclassify it without explicit confirmation from the user or accountable spec owner.
+Treat the approved artifact set as part of the reviewed plan. Revisit artifact selection only through this workflow; do not ask implementation to re-litigate it.
 
 ### 3. Write and approve the selected specs
 

--- a/.agents/skills/spec-driven-implementation/SKILL.md
+++ b/.agents/skills/spec-driven-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-driven-implementation
-description: Drives a pragmatic spec-first workflow by choosing among no spec, PRODUCT.md only, standalone TECH.md with technical safety and preservation guarantees, or both. Use when starting significant feature or hardening work, planning agent-driven implementation, or deciding which specs should be checked into source control.
+description: Guides a pragmatic spec-first workflow for substantial work, including deciding which specs add value, getting them approved, and keeping them current through implementation. Use when starting a significant feature or hardening effort, planning agent-driven implementation, or deciding which specs should be checked into source control.
 ---
 
 # spec-driven-implementation

--- a/.agents/skills/spec-driven-implementation/SKILL.md
+++ b/.agents/skills/spec-driven-implementation/SKILL.md
@@ -73,7 +73,7 @@ Evaluate the size, ambiguity, and risk of the work. If specs will not meaningful
 
 Do not assume `PRODUCT.md` comes first or that both documents are required. Choose no spec, `PRODUCT.md` only, `TECH.md` only, or both using the independent-value and semantic-preservation tests above.
 
-Treat the approved artifact set as part of the reviewed plan. Revisit artifact selection only through this workflow; do not ask implementation to re-litigate it.
+Treat the approved artifact set as part of the reviewed plan. Route any later artifact-selection review back through this workflow while implementation consumes the settled artifact set.
 
 ### 3. Write and approve the selected specs
 
@@ -125,7 +125,7 @@ Update `TECH.md`, when it exists, when:
 
 The checked-in specs should describe the change that actually ships, not just the initial intent. Keep those spec updates in the same PR as the related code changes whenever practical.
 
-If a spec stops adding independent value as the design evolves, propose consolidating any durable guarantees into the remaining source of truth. Get explicit confirmation from the user or accountable spec owner before deleting or reclassifying an approved spec.
+If evolving design calls the approved artifact set into question, return to the artifact-selection step. Explain the proposed artifact set, show how every durable guarantee remains represented, and get explicit confirmation from the user or accountable spec owner before changing the approved artifact set.
 
 ### 6. Verify behavior against the spec
 

--- a/.agents/skills/spec-driven-implementation/SKILL.md
+++ b/.agents/skills/spec-driven-implementation/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: spec-driven-implementation
-description: Drive a spec-first workflow for substantial features by writing PRODUCT.md before implementation, writing TECH.md when warranted, and keeping both specs updated as implementation evolves. Use when starting a significant feature, planning agent-driven implementation, or when the user wants product and tech specs checked into source control.
+description: Drives a pragmatic spec-first workflow by choosing among no spec, PRODUCT.md only, standalone TECH.md with behavioral guarantees, or both. Use when starting significant feature or hardening work, planning agent-driven implementation, or deciding which specs should be checked into source control.
 ---
 
 # spec-driven-implementation
 
-Drive a spec-first workflow for substantial features in Warp.
+Drive a spec-first workflow for substantial work in Warp.
 
 ## Overview
 
-Use this skill for significant features where a written spec will improve implementation quality, reduce ambiguity, or make review easier. Be pragmatic: not every change needs specs.
+Use this skill for significant work where a written spec will improve implementation quality, reduce ambiguity, or make review easier. Be pragmatic: not every change needs specs, and not every technically complex change needs a product spec.
 
-Specs should usually live in:
+Specs may live in:
 
 - `specs/<linear-ticket-number>/PRODUCT.md`
 - `specs/<linear-ticket-number>/TECH.md`
@@ -23,7 +23,7 @@ For example:
 
 `specs/` should contain only ticket-named directories as direct children. Do not create engineer-named subdirectories or feature-slug directories there.
 
-If a relevant Linear issue does not already exist, create one before writing specs. Use the Linear MCP tools directly:
+Use a relevant Linear issue when one already exists. Only create one when the user explicitly asks; in that case use the Linear MCP tools directly:
 
 - `list_teams` to find the appropriate team
 - `list_issue_labels` to inspect the expected labels/tags
@@ -31,7 +31,7 @@ If a relevant Linear issue does not already exist, create one before writing spe
 
 If the correct team or labels are not obvious from the request and surrounding context, use `ask_user_question` to clarify rather than guessing.
 
-These specs should largely be written by agents, not by hand, and should be checked into source control so they can be reviewed and kept current with the code.
+Specs should largely be written by agents, not by hand, and should be checked into source control when their ongoing review value exceeds the cost of keeping them current with the code.
 
 ## When specs are required
 
@@ -51,27 +51,36 @@ Specs are often unnecessary for:
 
 For pure UI changes, the product spec is often useful while the tech spec may be unnecessary.
 
+Choose the smallest document set that adds independent value:
+
+- **No spec** — Small, clear work that is better captured by the issue, code, and tests.
+- **`PRODUCT.md` only** — Meaningful user-facing or public-contract behavior is ambiguous, but implementation is straightforward.
+- **`TECH.md` only** — Internal hardening, a bug fix, refactor, migration, lifecycle/concurrency work, or other technically complex change that preserves existing product semantics. Include a concise `Behavioral guarantees` section.
+- **Both** — Product behavior and technical design each contain meaningful, independently reviewable decisions.
+
+Technical size or cross-cutting scope alone is not a reason to create `PRODUCT.md`.
+
 ## Workflow
 
-### 1. Decide whether the feature needs specs
+### 1. Decide whether the work needs specs
 
-Evaluate the size, ambiguity, and risk of the feature. If specs will not meaningfully improve execution or review, skip them and focus on verification instead.
+Evaluate the size, ambiguity, and risk of the work. If specs will not meaningfully improve execution or review, skip them and focus on verification instead.
 
-### 2. Write the product spec first
+### 2. Choose and write only the warranted specs
 
-Before implementation, create `PRODUCT.md` describing the desired user-facing behavior.
+Do not assume `PRODUCT.md` comes first or that both documents are required.
 
-Use the `write-product-spec` skill to produce it. The product spec should define:
+Use the `write-product-spec` skill only when the product behavior has independent review value. The product spec should define:
 
 - what problem is being solved
 - the desired user experience
-- invariants and edge cases
-- success criteria
-- how the behavior will be validated
+- meaningful product invariants and user-visible edge cases
 
-If the feature has UI or interaction design, ask for a Figma mock if one exists. If there is no mock, continue but call that out explicitly in the product spec.
+If the work has UI or interaction design, ask for a Figma mock if one exists. If there is no mock, continue but call that out explicitly in the product spec.
 
 Reference the Linear issue in the spec when one exists. Because specs live under `specs/<linear-ticket-number>/...`, this should usually be straightforward.
+
+For technically complex work that preserves existing product semantics, skip `PRODUCT.md` and use a standalone `TECH.md` with concise behavioral guarantees.
 
 ### 3. Write the tech spec when warranted
 
@@ -88,9 +97,9 @@ It is acceptable to write the tech spec after an e2e prototype if that leads to 
 
 ### 4. Implement approved specs
 
-After the specs are approved, use the `implement-specs` skill to build from the approved `PRODUCT.md` and `TECH.md`.
+After the warranted specs are approved, use the `implement-specs` skill to build from whichever approved documents exist.
 
-The implementation can often be pushed in the same PR as the product and tech specs. As the engineer iterates, keep `PRODUCT.md`, `TECH.md`, code changes, and tests in that same PR so the review reflects the feature that will actually ship.
+The implementation can often be pushed in the same PR as the specs. As the engineer iterates, keep the applicable specs, code changes, and tests in that same PR so the review reflects the change that will actually ship.
 
 For large features, the implementer may optionally offer:
 
@@ -103,24 +112,26 @@ These are optional aids, not required outputs.
 
 If implementation changes from the spec, update the spec rather than leaving it stale.
 
-Update `PRODUCT.md` when:
+Update `PRODUCT.md`, when it exists, when:
 
 - user-facing behavior changes
-- success criteria change
+- meaningful product guarantees change
 - UX details or edge cases change
 
-Update `TECH.md` when:
+Update `TECH.md`, when it exists, when:
 
 - the implementation approach changes
 - architectural boundaries move
 - risks, dependencies, or rollout details change
 - the testing or validation plan changes
 
-The checked-in specs should describe the feature that actually ships, not just the initial intent. Keep those spec updates in the same PR as the related code changes whenever practical.
+The checked-in specs should describe the change that actually ships, not just the initial intent. Keep those spec updates in the same PR as the related code changes whenever practical.
+
+If a spec stops adding independent value as the design evolves, consolidate any durable guarantees into the remaining source of truth and remove the redundant document rather than maintaining two synchronized copies.
 
 ### 6. Verify behavior against the spec
 
-Before considering the work complete, make sure verification maps back to the specs. Prefer tests and artifacts that validate the product behavior directly:
+Before considering the work complete, make sure verification maps back to the applicable specs. Prefer tests and artifacts that validate the product behavior or standalone behavioral guarantees directly:
 
 - unit tests and regression coverage that follow the repository's local testing conventions
 - integration tests for critical user flows
@@ -131,8 +142,9 @@ Before considering the work complete, make sure verification maps back to the sp
 
 - Be pragmatic above all else.
 - Write specs to improve input quality for agents, not as ceremony.
+- Choose document types based on independent review value, not implementation size alone.
 - Keep product specs behavior-oriented and implementation-light.
-- Keep tech specs implementation-oriented and grounded in current codebase patterns.
+- Keep tech specs implementation-oriented and grounded in current codebase patterns; use concise behavioral guarantees when no product spec is warranted.
 - When a spec references relevant code chunks, include the inspected commit SHA in the file reference when possible and link the reference to the exact GitHub `blob/<sha>/...#Lx-Ly` lines.
 - Use review time to validate specs and behavior, not to over-index on code style nits.
 

--- a/.agents/skills/validate-changes-match-specs/SKILL.md
+++ b/.agents/skills/validate-changes-match-specs/SKILL.md
@@ -87,7 +87,7 @@ If the user chooses to append a follow-up comment, draft the comment for approva
 
 ## Security spec validation
 
-When a security, privacy, compliance, permissions, auth, data-handling, or logging spec is present, validate it especially thoroughly. Treat the security spec as a set of explicit guarantees and threat mitigations, not as high-level guidance.
+When any relevant spec contains security, privacy, compliance, permissions, auth, data-handling, or logging commitments, validate them especially thoroughly. Treat those commitments as explicit guarantees and threat mitigations, not as high-level guidance.
 
 For each security commitment, verify both:
 
@@ -107,7 +107,7 @@ Check implementation details such as:
 - rate limits, abuse cases, replay behavior, and confused-deputy risks
 - test coverage for both allowed and denied cases
 
-If you discover a plausible security gap that is not covered by the security spec, include it as a proposed spec amendment rather than ignoring it because it is missing from the spec. Mark it as `security amendment` in the mismatch report, explain the risk, cite the code or behavior that exposed it, and ask the user whether to update the spec, update the implementation, both, or acknowledge without changes.
+If you discover a plausible security gap that is not covered by the approved specs, include it as a proposed spec amendment rather than ignoring it because it is missing from the specs. Mark it as `security amendment` in the mismatch report, explain the risk, cite the code or behavior that exposed it, and ask the user whether to update the spec, update the implementation, both, or acknowledge without changes.
 
 Do not make speculative security claims. If evidence is incomplete, label the item as a validation gap and describe exactly what would need to be checked.
 
@@ -141,16 +141,16 @@ If the user skips cloud validation, continue with local/static validation and me
 
 Treat a mismatch as material when any of these are true:
 
-- The implementation omits behavior required by the product spec.
-- The implementation behaves differently from the product spec in a user-visible way.
-- The implementation uses a technical approach that contradicts the tech spec in a way that matters for correctness, maintainability, rollout, or review.
-- The implementation adds meaningful behavior or scope not described by the specs.
-- Security, privacy, permission, or logging behavior differs from the security or product spec.
-- A discovered security gap is not covered by an existing security spec and should be considered as a spec amendment.
+- The implementation omits an approved behavior, design, security, migration, rollout, or validation commitment.
+- The implementation produces user-visible behavior that differs materially from an approved commitment.
+- The implementation contradicts an approved technical or design decision in a way that matters for correctness, maintainability, rollout, or review.
+- The implementation adds meaningful behavior or scope not described by the approved specs.
+- Security, privacy, permission, or logging behavior differs from approved commitments.
+- A discovered security gap is not covered by the approved specs and should be considered as a spec amendment.
 - The implementation does not match the last acknowledged resolution on a PR review comment.
 - Required migrations, rollout steps, feature flags, telemetry, validation, or cleanup are missing.
-- Tests or validation promised by the spec are absent or materially weaker than described.
-- The spec still describes behavior that was deliberately changed during implementation.
+- Tests or validation promised by an approved spec are absent or materially weaker than described.
+- An approved spec still describes behavior that was deliberately changed during implementation.
 
 Do not flag harmless implementation details, naming differences, or local refactors when the implementation preserves the spec's intent.
 
@@ -222,9 +222,9 @@ When the user chooses to update implementation, modify code, tests, docs, migrat
 - Prefer updating implementation when the spec describes required user behavior, security behavior, compatibility, migration, or validation guarantees that the code does not satisfy.
 - If a mismatch affects security or privacy, be explicit about the risk before asking for a resolution.
 - If two mismatch decisions conflict, stop and ask for clarification before editing.
-- Keep product specs user-focused and implementation-light.
-- Keep tech specs grounded in actual architecture and code paths.
-- Keep security specs explicit about threats, boundaries, and mitigations.
+- Do not treat a commitment's placement in a particular spec file as a mismatch.
+- Do not relocate or reclassify approved content unless the user explicitly chooses that resolution.
+- When updating a spec, preserve its existing role and style unless the user asks for broader restructuring.
 
 ## Validation after changes
 

--- a/.agents/skills/validate-changes-match-specs/SKILL.md
+++ b/.agents/skills/validate-changes-match-specs/SKILL.md
@@ -26,7 +26,7 @@ Prefer repository conventions when known. Otherwise:
 - Use `main`, `master`, or `develop` only when that is clearly the repository's base branch.
 - Use `git merge-base` and `git diff --name-only <base>...HEAD` to find files introduced or modified by the branch.
 
-Look for specs introduced or modified by the change, especially under `specs/`.
+Start with specs introduced or modified by the change, especially under `specs/`. For every relevant `specs/<id>/` directory, also read its approved sibling specs, including siblings that the current change did not modify.
 
 Common spec names include:
 
@@ -37,9 +37,9 @@ Common spec names include:
 - `SECURITY.md`
 - `security.md`
 
-Treat any markdown file bundled under a relevant `specs/<id>/` directory as a valid spec candidate. The id may be a ticket, issue, or feature name. Examples include focused specs such as `MIGRATION.md`, `ROLLBACK.md`, `PRIVACY.md`, `API.md`, or `TESTING.md`.
+Treat a file as authoritative when the available evidence identifies it as an approved source of commitments. Focused supplemental specs may include `MIGRATION.md`, `ROLLBACK.md`, `PRIVACY.md`, `API.md`, or `TESTING.md`. Treat other markdown files in a relevant `specs/<id>/` directory as supporting context. If a document's approval status is unclear, ask before treating its contents as commitments. The id may be a ticket, issue, or feature name.
 
-If no specs were introduced or modified, look for existing specs referenced by the PR description, commit messages, branch name, changed files, or nearby `specs/` directories. If there is still no relevant spec, stop and report that there is no spec to validate against.
+Also look for existing specs referenced by the PR description, commit messages, branch name, changed files, or nearby `specs/` directories. If there is still no relevant spec, stop and report that there is no spec to validate against.
 
 ## Context gathering
 
@@ -81,7 +81,6 @@ Use the same `ask_user_question` flow for these inconsistencies. For review-comm
 - Append a follow-up comment explaining why the implementation is being left as-is.
 - Explain this inconsistency before deciding.
 - Acknowledge without changes.
-- `Other...`
 
 If the user chooses to append a follow-up comment, draft the comment for approval before posting it. Do not post GitHub comments without explicit approval. Prefix agent-authored follow-up comments with `[Warp Agent]`.
 
@@ -123,7 +122,6 @@ Call `ask_user_question` with options like:
 
 - `Launch cloud computer-use agents to validate product behavior`
 - `Skip cloud computer-use validation`
-- `Other...`
 
 If the user chooses cloud validation, launch multiple Oz cloud agents with computer use enabled as part of this validation flow. Split the product spec's user-visible behaviors into independent validation assignments, such as one child agent per major flow, user role, platform, or acceptance-criteria group. Each child agent should receive:
 
@@ -178,9 +176,6 @@ When mismatches exist, the first `ask_user_question` call must ask how the user 
 
 - `Resolve one-by-one`
 - `Collect all decisions, then apply in a batch`
-- `Other...`
-
-Every `ask_user_question` call in this skill must include an `Other...` option for custom instructions.
 
 ### One-by-one mode
 
@@ -206,7 +201,6 @@ For each mismatch, call `ask_user_question` with options tailored to the specifi
 - Update the spec to match the implementation.
 - Explain this mismatch before deciding.
 - Acknowledge without changes.
-- `Other...`
 
 When the user selects explanation, provide concise context about why the mismatch exists, what would change under each resolution path, and any risk or review implications. Then ask about the same mismatch again.
 
@@ -244,7 +238,6 @@ Call `ask_user_question` with options like:
 - `Commit only`
 - `Commit and push to origin`
 - `Do not commit`
-- `Other...`
 
 If the user chooses to commit:
 

--- a/.agents/skills/validate-changes-match-specs/SKILL.md
+++ b/.agents/skills/validate-changes-match-specs/SKILL.md
@@ -222,9 +222,8 @@ When the user chooses to update implementation, modify code, tests, docs, migrat
 - Prefer updating implementation when the spec describes required user behavior, security behavior, compatibility, migration, or validation guarantees that the code does not satisfy.
 - If a mismatch affects security or privacy, be explicit about the risk before asking for a resolution.
 - If two mismatch decisions conflict, stop and ask for clarification before editing.
-- Do not treat a commitment's placement in a particular spec file as a mismatch.
-- Do not relocate or reclassify approved content unless the user explicitly chooses that resolution.
-- When updating a spec, preserve its existing role and style unless the user asks for broader restructuring.
+- Evaluate commitments on their substance regardless of which approved spec contains them.
+- Apply each selected spec correction in place, preserving the spec's existing role and style and limiting the edit to the mismatch resolution explicitly selected by the user.
 
 ## Validation after changes
 

--- a/.agents/skills/validate-changes-match-specs/SKILL.md
+++ b/.agents/skills/validate-changes-match-specs/SKILL.md
@@ -37,7 +37,7 @@ Common spec names include:
 - `SECURITY.md`
 - `security.md`
 
-Treat any markdown file bundled under a relevant `specs/<issue-number>/` directory as a valid spec candidate. Examples include focused specs such as `MIGRATION.md`, `ROLLBACK.md`, `PRIVACY.md`, `API.md`, or `TESTING.md`.
+Treat any markdown file bundled under a relevant `specs/<id>/` directory as a valid spec candidate. The id may be a ticket, issue, or feature name. Examples include focused specs such as `MIGRATION.md`, `ROLLBACK.md`, `PRIVACY.md`, `API.md`, or `TESTING.md`.
 
 If no specs were introduced or modified, look for existing specs referenced by the PR description, commit messages, branch name, changed files, or nearby `specs/` directories. If there is still no relevant spec, stop and report that there is no spec to validate against.
 

--- a/.agents/skills/write-product-spec/SKILL.md
+++ b/.agents/skills/write-product-spec/SKILL.md
@@ -1,26 +1,42 @@
 ---
 name: write-product-spec
-description: Write a PRODUCT.md spec for a significant user-facing feature in Warp, focused on detailed behavior and validation. Use when the user asks for a product spec, desired behavior doc, or PRD, wants to define feature behavior before implementation, or when the feature is substantial or behaviorally ambiguous enough that a written spec would improve implementation or review.
+description: Writes a PRODUCT.md only when a significant user-facing feature or durable public consumer contract has meaningful behavior decisions worth reviewing independently of implementation. Use when the user asks for a product spec, desired behavior doc, or PRD; first recommend a standalone TECH.md or no product spec for internal hardening, bug fixes, refactors, and other work that preserves existing product semantics.
 ---
 
 # write-product-spec
 
-Write a `PRODUCT.md` spec for a significant feature in Warp.
+Write a `PRODUCT.md` spec only when it adds durable product-level value.
 
 ## Overview
 
-The product spec should make the desired behavior unambiguous enough that an agent can implement it correctly and avoid regressions. Describe the feature purely from the user's perspective — what the user sees, does, and experiences, and the invariants that must hold for them. Do not include implementation details (internal types, state layout, module boundaries, data flow, algorithms).
+The product spec should make meaningful product behavior decisions unambiguous enough that an agent can implement them correctly and reviewers can evaluate them independently of the implementation. Describe the feature purely from the user's perspective — what the user sees, does, and experiences, and the stable guarantees that must hold for them. Do not include implementation details (internal types, state layout, module boundaries, data flow, algorithms).
 
-"User" is not limited to the end user of the Warp app. It means whoever consumes the surface being designed:
+"User" includes a human using Warp and consumers of a deliberately exposed, durable product surface:
 
 - For UI / UX features: the human using Warp.
-- For a data model: the code that reads and writes that model.
-- For an API, protocol, or library: the callers of that API — other services, client code, plugins, or agents.
+- For a public API, versioned protocol, or externally consumed library: the callers of that surface — other services, client code, plugins, or agents.
 - For a CLI tool or developer-facing surface: the developer invoking it.
 
-The spec should describe behavior from that consumer's perspective: the shape of the surface, the operations they can perform, what they see back, invariants they can rely on, and edge cases they must handle — without prescribing how the surface is implemented underneath.
+Internal code that calls a data model, module, or helper is not by itself a product audience. Internal contracts, lifecycle transitions, failure handling, and correctness matrices belong in `TECH.md` and tests unless they create a separately meaningful public contract.
 
-Implementation details, validation, and test planning live in a companion `TECH.md`, produced by the `write-tech-spec` skill. Writing the product spec is usually the first step of a two-step process: once `PRODUCT.md` is agreed on, invoke `write-tech-spec` to produce `TECH.md` for the same feature (or let the user know that's the expected next step). The product spec should be written so the tech spec can be written directly from it.
+A product spec does not imply that a tech spec is needed, and a tech spec does not imply that a product spec is needed. When both add independent value, implementation details, validation, and test planning live in the companion `TECH.md`, produced by the `write-tech-spec` skill.
+
+## First decide whether `PRODUCT.md` adds value
+
+Before writing, decide which artifact best fits the work:
+
+- **Create `PRODUCT.md`** when there are meaningful user-facing or public-contract choices that product, design, API consumers, or reviewers can evaluate independently of implementation.
+- **Use only `TECH.md` with a concise `Behavioral guarantees` section** when the work is technically complex or risky but preserves existing product semantics, such as internal hardening, a bug fix, a refactor, lifecycle recovery, concurrency correctness, or migration plumbing.
+- **Create no spec** when the work is small, clear, and better captured by the issue, code, and tests.
+- **Create both** only when product behavior and technical design each have independent ambiguity or review value.
+
+Ask:
+
+- Would `PRODUCT.md` still be useful if the implementation changed completely?
+- Does it contain decisions that a product/design stakeholder or public consumer should review?
+- Will it be an independent source of truth, rather than a less precise duplicate of `TECH.md` and its test plan?
+
+If the answers are no, do not create `PRODUCT.md`. If the user explicitly requested one, explain why it may be redundant and recommend the better artifact before proceeding.
 
 Write specs to `specs/<id>/PRODUCT.md`, where `<id>` is one of:
 
@@ -34,7 +50,7 @@ Ticket / issue references are optional. If the user has a Linear ticket or GitHu
 
 ## Before writing
 
-Gather only the context you need: directory id (Linear ticket, GitHub issue, or feature name), feature summary, target users, key behaviors, edge cases, and how the feature will be validated. Use `ask_user_question` for missing context rather than guessing.
+Run the value test above first. If `PRODUCT.md` is warranted, gather only the context you need: directory id (Linear ticket, GitHub issue, or feature name), feature summary, target users, meaningful behavior choices, and user-visible edge cases. Use `ask_user_question` for missing context rather than guessing.
 
 ### Figma mocks
 
@@ -51,7 +67,7 @@ Do not silently drop design context; an explicit "none" is preferable to no ment
 Required sections:
 
 1. **Summary** — 1–3 sentences describing the feature and desired outcome.
-2. **Behavior** — The meat of the spec. An exhaustive English description of how the feature works, written as numbered, testable invariants. See "The Behavior section" below — this is where the spec earns its length, and everything else should stay thin to avoid duplicating it.
+2. **Behavior** — The meat of the spec. A right-sized English description of the meaningful product behavior and stable guarantees, preferably written as numbered, testable invariants. See "The Behavior section" below — this is where the spec earns its length, and everything else should stay thin to avoid duplicating it.
 
 Optional sections — include only when they add signal beyond the core. Omit the heading entirely if empty; do not write "None" as a placeholder.
 
@@ -60,33 +76,34 @@ Optional sections — include only when they add signal beyond the core. Omit th
 - **Figma** — Include with a link when one exists, or an explicit `Figma: none provided` note when design matters but no mock exists. Omit entirely for non-visual features. See "Figma mocks" above.
 - **Open questions** — Prefer inline `**Open question:** …` next to the relevant behavior. Include a dedicated section only if there are multiple unresolved questions worth collecting.
 
-Do not include Validation, Success criteria, or Testing sections. Validation and test planning live in the companion `TECH.md` (produced by `write-tech-spec`). Write Behavior as numbered invariants that are testable on their own — the tech spec can reference them directly.
+Do not include Validation, Success criteria, or Testing sections. Validation and test planning live in `TECH.md` when one exists. Write Behavior as testable guarantees that a tech spec can reference without duplicating them.
 
 ## The Behavior section
 
 Behavior is the spec. Everything else is framing.
 
-The goal of Behavior is a complete English description of how the feature works, detailed enough that a tech spec can be written directly from it without the author having to guess or re-derive product intent. If a reader finishes Behavior with questions about what the feature does in some situation, the section is not done.
+The goal of Behavior is to resolve product ambiguity, not to enumerate every technical state transition or test case. It should be detailed enough that an implementer does not need to guess about meaningful product intent. Stop when additional detail would merely duplicate the technical design, lifecycle matrix, or validation plan.
 
-Describe, at minimum:
+Describe the items below only when they are relevant to the product surface:
 
 - Default behavior and the happy-path user flow.
 - Every user-visible state and the transitions between them.
 - All inputs the user can provide and how the feature responds.
 - Empty states, error states, loading / pending states, and cancellation.
-- Edge cases a reasonable implementer would not think to ask about — permission denied, offline, timeouts, races between state changes, multiple concurrent instances, stale or missing data, focus loss mid-interaction, interactions with adjacent features.
+- User-visible edge cases and decisions a reasonable implementer would not think to ask about — permission denied, offline behavior, cancellation, focus loss, and interactions with adjacent features.
 - Keyboard, accessibility, and focus expectations where relevant.
 - Invariants that must hold at all times and behaviors that must not regress.
 
-Length Behavior to match the feature. Trivial features may need a handful of invariants; complex features may need many, with sub-sections per flow or state. The rest of the spec should stay thin so Behavior can be as exhaustive as the feature requires without producing a bloated document overall. Err toward enumerating one more edge case rather than one fewer.
+Do not enumerate internal races, stale events, missing messages, concurrency cases, persistence details, or downstream test expectations unless they change the user-visible or public-consumer contract. Put those in `TECH.md` and tests. Length Behavior to match the amount of genuine product ambiguity, not the implementation's technical complexity.
 
 ## Length heuristic
 
-Behavior should be as long as the feature requires — do not truncate edge cases to hit a line target. The heuristic below applies to everything around Behavior (Summary, optional sections): keep that framing thin so the spec's total length reflects the feature's actual complexity, not structural overhead.
+Behavior should be as long as the product ambiguity requires. Do not inflate it to reflect technical complexity or to enumerate the validation matrix. The heuristic below applies to everything around Behavior (Summary, optional sections): keep that framing thin so the spec's total length reflects the product surface, not structural overhead.
 
-- Trivial fix or narrow UI tweak: no spec.
-- Small feature (single module, few edge cases): framing plus Behavior typically ~30–60 lines total.
-- Medium feature (cross-module, multiple states): typically ~80–150 lines total.
+- Bug fix, hardening, or refactor that preserves existing product semantics: no product spec. Use concise behavioral guarantees in `TECH.md` if a technical design is warranted.
+- Trivial feature or narrow UI tweak: usually no spec.
+- Small product surface with few meaningful decisions or edge cases: framing plus Behavior typically ~30–60 lines total.
+- Medium product surface with multiple user-visible states or interactions: typically ~80–150 lines total.
 - Large or behaviorally rich feature: longer is fine, and most of the length should live in Behavior.
 
 If you find yourself writing the same idea in Summary, Problem, Goals, and Behavior, collapse the framing — not the Behavior content.
@@ -95,13 +112,16 @@ If you find yourself writing the same idea in Summary, Problem, Goals, and Behav
 
 - Prefer concrete, observable behavior over aspirational wording.
 - Write Behavior as a list of invariants rather than prose when possible.
-- Capture invariants that must not regress and edge cases that are easy to miss.
+- Capture product invariants that must not regress and user-visible edge cases that are easy to miss.
+- Avoid mirroring a technical transition matrix or test plan in product language.
 - Avoid implementation details unless unavoidable for the UX.
 - Each section should earn its place — if a section would repeat another or contain only boilerplate, omit it.
 
 ## Keep the spec current
 
 Approved specs may ship in the same PR as the implementation. As implementation evolves, update `PRODUCT.md` in the same PR when user-facing behavior or UX details change. The checked-in spec should describe the feature that actually ships.
+
+If evolving design removes the distinct product semantics and `PRODUCT.md` becomes a duplicate of `TECH.md`, consolidate any remaining stable behavioral guarantees into `TECH.md` and remove the redundant product spec rather than maintaining both.
 
 For large features, the implementer may optionally keep a `DECISIONS.md` file summarizing concrete decisions made during design and implementation. Offer it when it would help future agents; otherwise skip it.
 
@@ -114,6 +134,8 @@ For large features, the implementer may optionally keep a `DECISIONS.md` file su
 ## Example Behavior section
 
 A sample Behavior section for a hypothetical feature: rendering GitHub-flavored Markdown tables in the Warp block list. It demonstrates the expected shape — numbered, testable, user-perspective invariants that enumerate defaults, edge cases, malformed input, streaming, selection/copy, search, sharing, theming, and cross-surface consistency, with one inline open question.
+
+This is intentionally a behaviorally rich, user-facing example. Do not use its length or exhaustiveness as the default for bug fixes, hardening, refactors, or internal technical work; those should usually have no `PRODUCT.md`.
 
 ````markdown
 ## Behavior

--- a/.agents/skills/write-product-spec/SKILL.md
+++ b/.agents/skills/write-product-spec/SKILL.md
@@ -111,11 +111,15 @@ If you find yourself writing the same idea in Summary, Problem, Goals, and Behav
 - Avoid implementation details unless unavoidable for the UX.
 - Each section should earn its place — if a section would repeat another or contain only boilerplate, omit it.
 
+## Approval handoff
+
+After drafting, present a concise summary of the material decisions and unresolved questions. When called by `spec-driven-implementation`, return this handoff so that workflow can coordinate approval across the selected specs. When called directly, ask the user or another explicitly identified human approver to resolve or explicitly defer every question that would affect implementation, then ask them to approve the spec or request revisions before it is treated as ready for implementation.
+
 ## Keep the spec current
 
 Approved specs may ship in the same PR as the implementation. As implementation evolves, update `PRODUCT.md` in the same PR when user-facing behavior, UX details, public contracts, or deliberately stable cross-team contracts change. The checked-in spec should describe the feature that actually ships.
 
-If evolving design changes the document's value, keep `PRODUCT.md` current for its approved behavior and return to `spec-driven-implementation` to revisit artifact selection. Surface material behavior changes for re-review; routine edits that keep the approved intent current do not require renewed approval.
+If evolving design changes the document's value, keep `PRODUCT.md` current for its approved behavior and return to `spec-driven-implementation` to revisit artifact selection. Present proposed material behavior changes to the user or another explicitly identified human approver and get explicit approval before updating the approved spec; routine edits that keep the approved intent current do not require renewed approval.
 
 For large features, the implementer may optionally keep a `DECISIONS.md` file summarizing concrete decisions made during design and implementation. Offer it when it would help future agents; otherwise skip it.
 

--- a/.agents/skills/write-product-spec/SKILL.md
+++ b/.agents/skills/write-product-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-product-spec
-description: Writes a PRODUCT.md only when a significant user-facing feature or durable public consumer contract has meaningful behavior decisions worth reviewing independently of implementation. Use when the user asks for a product spec, desired behavior doc, or PRD; first recommend a standalone TECH.md or no product spec for internal hardening, bug fixes, refactors, and other work that preserves existing product semantics.
+description: Writes a PRODUCT.md only when a significant user-facing feature or durable public or deliberately stable cross-team consumer contract has meaningful behavior decisions worth reviewing independently of implementation. Use when the user asks for a product spec, desired behavior doc, or PRD; first recommend a standalone TECH.md or no product spec for internal work whose relevant consumer semantics remain unchanged.
 ---
 
 # write-product-spec
@@ -15,9 +15,10 @@ The product spec should make meaningful product behavior decisions unambiguous e
 
 - For UI / UX features: the human using Warp.
 - For a public API, versioned protocol, or externally consumed library: the callers of that surface — other services, client code, plugins, or agents.
+- For a deliberately stable cross-team contract: the named teams or services whose compatibility expectations are intentionally defined and reviewed.
 - For a CLI tool or developer-facing surface: the developer invoking it.
 
-Internal code that calls a data model, module, or helper is not by itself a product audience. Internal contracts, lifecycle transitions, failure handling, and correctness matrices belong in `TECH.md` and tests unless they create a separately meaningful public contract.
+Internal code that calls a data model, module, or helper is not by itself a product audience. A cross-team contract qualifies only when its owners and consumers deliberately treat its semantics as stable and worth independent review. Other internal contracts, lifecycle transitions, failure handling, and correctness matrices belong in `TECH.md` and tests.
 
 A product spec does not imply that a tech spec is needed, and a tech spec does not imply that a product spec is needed. When both add independent value, implementation details, validation, and test planning live in the companion `TECH.md`, produced by the `write-tech-spec` skill.
 
@@ -25,15 +26,17 @@ A product spec does not imply that a tech spec is needed, and a tech spec does n
 
 Before writing, decide which artifact best fits the work:
 
-- **Create `PRODUCT.md`** when there are meaningful user-facing or public-contract choices that product, design, API consumers, or reviewers can evaluate independently of implementation.
-- **Use only `TECH.md` with a concise `Behavioral guarantees` section** when the work is technically complex or risky but preserves existing product semantics, such as internal hardening, a bug fix, a refactor, lifecycle recovery, concurrency correctness, or migration plumbing.
+- **Create `PRODUCT.md`** when there are meaningful user-facing, public-contract, or deliberately stable cross-team contract choices that product, design, consumers, or reviewers can evaluate independently of implementation.
+- **Use only `TECH.md` with concise `Technical safety and preservation guarantees`** when the work is technically complex or risky but preserves the relevant consumer semantics, such as internal hardening, a bug fix, a refactor, lifecycle recovery, concurrency correctness, or migration plumbing.
 - **Create no spec** when the work is small, clear, and better captured by the issue, code, and tests.
 - **Create both** only when product behavior and technical design each have independent ambiguity or review value.
+
+Before deciding not to create `PRODUCT.md`, state in one sentence whether user-visible, public, and deliberately stable cross-team consumer semantics — including failure and recovery behavior — change. If they change, explain briefly why the independent-value test still does not warrant a product spec; a narrow, obvious behavior change may still need no spec. Task labels such as "bug fix," "refactor," and "hardening" are not evidence that semantics remain unchanged.
 
 Ask:
 
 - Would `PRODUCT.md` still be useful if the implementation changed completely?
-- Does it contain decisions that a product/design stakeholder or public consumer should review?
+- Does it contain decisions that a product/design stakeholder, public consumer, or owner of a deliberately stable cross-team contract should review?
 - Will it be an independent source of truth, rather than a less precise duplicate of `TECH.md` and its test plan?
 
 If the answers are no, do not create `PRODUCT.md`. If the user explicitly requested one, explain why it may be redundant and recommend the better artifact before proceeding.
@@ -76,7 +79,7 @@ Optional sections — include only when they add signal beyond the core. Omit th
 - **Figma** — Include with a link when one exists, or an explicit `Figma: none provided` note when design matters but no mock exists. Omit entirely for non-visual features. See "Figma mocks" above.
 - **Open questions** — Prefer inline `**Open question:** …` next to the relevant behavior. Include a dedicated section only if there are multiple unresolved questions worth collecting.
 
-Do not include Validation, Success criteria, or Testing sections. Validation and test planning live in `TECH.md` when one exists. Write Behavior as testable guarantees that a tech spec can reference without duplicating them.
+Do not include Validation, Success criteria, or Testing sections. Validation and test planning live in `TECH.md` when one exists. For PRODUCT-only work, keep a lightweight validation map in the implementation plan or PR. Write Behavior as testable guarantees that verification can reference without duplicating them.
 
 ## The Behavior section
 
@@ -94,13 +97,13 @@ Describe the items below only when they are relevant to the product surface:
 - Keyboard, accessibility, and focus expectations where relevant.
 - Invariants that must hold at all times and behaviors that must not regress.
 
-Do not enumerate internal races, stale events, missing messages, concurrency cases, persistence details, or downstream test expectations unless they change the user-visible or public-consumer contract. Put those in `TECH.md` and tests. Length Behavior to match the amount of genuine product ambiguity, not the implementation's technical complexity.
+Do not enumerate internal races, stale events, missing messages, concurrency cases, persistence details, or downstream test expectations unless they change a consumer contract that belongs in `PRODUCT.md`. Put those in `TECH.md` and tests. Length Behavior to match the amount of genuine product ambiguity, not the implementation's technical complexity.
 
 ## Length heuristic
 
 Behavior should be as long as the product ambiguity requires. Do not inflate it to reflect technical complexity or to enumerate the validation matrix. The heuristic below applies to everything around Behavior (Summary, optional sections): keep that framing thin so the spec's total length reflects the product surface, not structural overhead.
 
-- Bug fix, hardening, or refactor that preserves existing product semantics: no product spec. Use concise behavioral guarantees in `TECH.md` if a technical design is warranted.
+- Bug fix, hardening, or refactor whose one-sentence preservation check confirms unchanged relevant consumer semantics: no product spec. Use concise technical safety and preservation guarantees in `TECH.md` if a technical design is warranted.
 - Trivial feature or narrow UI tweak: usually no spec.
 - Small product surface with few meaningful decisions or edge cases: framing plus Behavior typically ~30–60 lines total.
 - Medium product surface with multiple user-visible states or interactions: typically ~80–150 lines total.
@@ -119,9 +122,9 @@ If you find yourself writing the same idea in Summary, Problem, Goals, and Behav
 
 ## Keep the spec current
 
-Approved specs may ship in the same PR as the implementation. As implementation evolves, update `PRODUCT.md` in the same PR when user-facing behavior or UX details change. The checked-in spec should describe the feature that actually ships.
+Approved specs may ship in the same PR as the implementation. As implementation evolves, update `PRODUCT.md` in the same PR when user-facing behavior, UX details, public contracts, or deliberately stable cross-team contracts change. The checked-in spec should describe the feature that actually ships.
 
-If evolving design removes the distinct product semantics and `PRODUCT.md` becomes a duplicate of `TECH.md`, consolidate any remaining stable behavioral guarantees into `TECH.md` and remove the redundant product spec rather than maintaining both.
+If evolving design removes the distinct product semantics and `PRODUCT.md` becomes a duplicate of `TECH.md`, propose consolidating any remaining stable guarantees into `TECH.md`. Get explicit confirmation from the user or accountable spec owner before deleting or reclassifying an approved product spec. Surface material behavior changes for re-review; routine edits that keep the approved intent current do not require renewed approval.
 
 For large features, the implementer may optionally keep a `DECISIONS.md` file summarizing concrete decisions made during design and implementation. Offer it when it would help future agents; otherwise skip it.
 

--- a/.agents/skills/write-product-spec/SKILL.md
+++ b/.agents/skills/write-product-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-product-spec
-description: Writes a consumer-behavior-focused PRODUCT.md for significant user-facing features and durable public or deliberately stable cross-team consumer contracts. Use when the user asks for a product spec, desired behavior doc, or PRD; right-sizes the document to genuine product ambiguity and avoids duplicating technical design.
+description: Writes a consumer-behavior-focused PRODUCT.md spec. Use when the user asks for a product spec, desired behavior document, or PRD.
 ---
 
 # write-product-spec
@@ -24,13 +24,13 @@ A product spec does not imply that a tech spec is needed, and a tech spec does n
 
 ## Right-size `PRODUCT.md` around its independent value
 
-If the artifact set has not been chosen, use `spec-driven-implementation` to decide which specs add value. When the user directly asks for `PRODUCT.md`, honor that choice. Use the questions below to right-size the document, flag likely redundancy, and avoid treating technical complexity as product ambiguity:
+If the artifact set has not been chosen, use `spec-driven-implementation` to decide which specs add value. When the user directly asks for `PRODUCT.md`, honor that choice. Use the questions below to right-size the document and avoid treating technical complexity as product ambiguity:
 
 - Would `PRODUCT.md` still be useful if the implementation changed completely?
 - Does it contain decisions that a product/design stakeholder, public consumer, or owner of a deliberately stable cross-team contract should review?
 - Will it be an independent source of truth, rather than a less precise duplicate of `TECH.md` and its test plan?
 
-If the answers are no, explain why `PRODUCT.md` may be redundant and recommend the better artifact, but continue if the user still wants the document.
+Use the answers to focus the requested document on its independently valuable consumer decisions. Do not use this skill to recommend replacing or removing a directly requested `PRODUCT.md`.
 
 Write specs to `specs/<id>/PRODUCT.md`, where `<id>` is one of:
 
@@ -94,8 +94,8 @@ Do not enumerate internal races, stale events, missing messages, concurrency cas
 
 Behavior should be as long as the product ambiguity requires. Do not inflate it to reflect technical complexity or to enumerate the validation matrix. The heuristic below applies to everything around Behavior (Summary, optional sections): keep that framing thin so the spec's total length reflects the product surface, not structural overhead.
 
-- Bug fix, hardening, or refactor that preserves relevant consumer semantics: `PRODUCT.md` is usually unnecessary. If requested, keep it focused on any genuine consumer decisions and put technical safety and preservation guarantees in `TECH.md` when a technical design is warranted.
-- Trivial feature or narrow UI tweak: usually no spec.
+- Bug fix, hardening, or refactor that preserves relevant consumer semantics: keep the requested product spec focused on any genuine consumer decisions and leave technical safety and preservation guarantees to `TECH.md` when one exists.
+- Trivial feature or narrow UI tweak: keep the requested product spec brief and focused on the few meaningful decisions.
 - Small product surface with few meaningful decisions or edge cases: framing plus Behavior typically ~30–60 lines total.
 - Medium product surface with multiple user-visible states or interactions: typically ~80–150 lines total.
 - Large or behaviorally rich feature: longer is fine, and most of the length should live in Behavior.
@@ -115,7 +115,7 @@ If you find yourself writing the same idea in Summary, Problem, Goals, and Behav
 
 Approved specs may ship in the same PR as the implementation. As implementation evolves, update `PRODUCT.md` in the same PR when user-facing behavior, UX details, public contracts, or deliberately stable cross-team contracts change. The checked-in spec should describe the feature that actually ships.
 
-If evolving design removes the distinct product semantics and `PRODUCT.md` becomes a duplicate of `TECH.md`, propose consolidating any remaining stable guarantees into `TECH.md`. Get explicit confirmation from the user or accountable spec owner before deleting or reclassifying an approved product spec. Surface material behavior changes for re-review; routine edits that keep the approved intent current do not require renewed approval.
+If evolving design changes the document's value, keep `PRODUCT.md` current for its approved behavior and surface any proposed artifact-set change through `spec-driven-implementation` rather than consolidating, removing, or reclassifying it here. Surface material behavior changes for re-review; routine edits that keep the approved intent current do not require renewed approval.
 
 For large features, the implementer may optionally keep a `DECISIONS.md` file summarizing concrete decisions made during design and implementation. Offer it when it would help future agents; otherwise skip it.
 
@@ -129,7 +129,7 @@ For large features, the implementer may optionally keep a `DECISIONS.md` file su
 
 A sample Behavior section for a hypothetical feature: rendering GitHub-flavored Markdown tables in the Warp block list. It demonstrates the expected shape — numbered, testable, user-perspective invariants that enumerate defaults, edge cases, malformed input, streaming, selection/copy, search, sharing, theming, and cross-surface consistency, with one inline open question.
 
-This is intentionally a behaviorally rich, user-facing example. Do not use its length or exhaustiveness as the default for bug fixes, hardening, refactors, or internal technical work; those should usually have no `PRODUCT.md`.
+This is intentionally a behaviorally rich, user-facing example. Do not use its length or exhaustiveness as the default for bug fixes, hardening, refactors, or internal technical work; keep any requested product spec for those changes short and focused on genuine consumer decisions.
 
 ````markdown
 ## Behavior

--- a/.agents/skills/write-product-spec/SKILL.md
+++ b/.agents/skills/write-product-spec/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: write-product-spec
-description: Writes a PRODUCT.md only when a significant user-facing feature or durable public or deliberately stable cross-team consumer contract has meaningful behavior decisions worth reviewing independently of implementation. Use when the user asks for a product spec, desired behavior doc, or PRD; first recommend a standalone TECH.md or no product spec for internal work whose relevant consumer semantics remain unchanged.
+description: Writes a consumer-behavior-focused PRODUCT.md for significant user-facing features and durable public or deliberately stable cross-team consumer contracts. Use when the user asks for a product spec, desired behavior doc, or PRD; right-sizes the document to genuine product ambiguity and avoids duplicating technical design.
 ---
 
 # write-product-spec
 
-Write a `PRODUCT.md` spec only when it adds durable product-level value.
+Write a consumer-behavior-focused `PRODUCT.md` spec that adds durable product-level value.
 
 ## Overview
 
@@ -22,24 +22,15 @@ Internal code that calls a data model, module, or helper is not by itself a prod
 
 A product spec does not imply that a tech spec is needed, and a tech spec does not imply that a product spec is needed. When both add independent value, implementation details, validation, and test planning live in the companion `TECH.md`, produced by the `write-tech-spec` skill.
 
-## First decide whether `PRODUCT.md` adds value
+## Right-size `PRODUCT.md` around its independent value
 
-Before writing, decide which artifact best fits the work:
-
-- **Create `PRODUCT.md`** when there are meaningful user-facing, public-contract, or deliberately stable cross-team contract choices that product, design, consumers, or reviewers can evaluate independently of implementation.
-- **Use only `TECH.md` with concise `Technical safety and preservation guarantees`** when the work is technically complex or risky but preserves the relevant consumer semantics, such as internal hardening, a bug fix, a refactor, lifecycle recovery, concurrency correctness, or migration plumbing.
-- **Create no spec** when the work is small, clear, and better captured by the issue, code, and tests.
-- **Create both** only when product behavior and technical design each have independent ambiguity or review value.
-
-Before deciding not to create `PRODUCT.md`, state in one sentence whether user-visible, public, and deliberately stable cross-team consumer semantics — including failure and recovery behavior — change. If they change, explain briefly why the independent-value test still does not warrant a product spec; a narrow, obvious behavior change may still need no spec. Task labels such as "bug fix," "refactor," and "hardening" are not evidence that semantics remain unchanged.
-
-Ask:
+If the artifact set has not been chosen, use `spec-driven-implementation` to decide which specs add value. When the user directly asks for `PRODUCT.md`, honor that choice. Use the questions below to right-size the document, flag likely redundancy, and avoid treating technical complexity as product ambiguity:
 
 - Would `PRODUCT.md` still be useful if the implementation changed completely?
 - Does it contain decisions that a product/design stakeholder, public consumer, or owner of a deliberately stable cross-team contract should review?
 - Will it be an independent source of truth, rather than a less precise duplicate of `TECH.md` and its test plan?
 
-If the answers are no, do not create `PRODUCT.md`. If the user explicitly requested one, explain why it may be redundant and recommend the better artifact before proceeding.
+If the answers are no, explain why `PRODUCT.md` may be redundant and recommend the better artifact, but continue if the user still wants the document.
 
 Write specs to `specs/<id>/PRODUCT.md`, where `<id>` is one of:
 
@@ -53,7 +44,7 @@ Ticket / issue references are optional. If the user has a Linear ticket or GitHu
 
 ## Before writing
 
-Run the value test above first. If `PRODUCT.md` is warranted, gather only the context you need: directory id (Linear ticket, GitHub issue, or feature name), feature summary, target users, meaningful behavior choices, and user-visible edge cases. Use `ask_user_question` for missing context rather than guessing.
+Use the value test above to right-size the document, then gather only the context you need: directory id (Linear ticket, GitHub issue, or feature name), feature summary, target users, meaningful behavior choices, and user-visible edge cases. Use `ask_user_question` for missing context rather than guessing.
 
 ### Figma mocks
 
@@ -103,7 +94,7 @@ Do not enumerate internal races, stale events, missing messages, concurrency cas
 
 Behavior should be as long as the product ambiguity requires. Do not inflate it to reflect technical complexity or to enumerate the validation matrix. The heuristic below applies to everything around Behavior (Summary, optional sections): keep that framing thin so the spec's total length reflects the product surface, not structural overhead.
 
-- Bug fix, hardening, or refactor whose one-sentence preservation check confirms unchanged relevant consumer semantics: no product spec. Use concise technical safety and preservation guarantees in `TECH.md` if a technical design is warranted.
+- Bug fix, hardening, or refactor that preserves relevant consumer semantics: `PRODUCT.md` is usually unnecessary. If requested, keep it focused on any genuine consumer decisions and put technical safety and preservation guarantees in `TECH.md` when a technical design is warranted.
 - Trivial feature or narrow UI tweak: usually no spec.
 - Small product surface with few meaningful decisions or edge cases: framing plus Behavior typically ~30–60 lines total.
 - Medium product surface with multiple user-visible states or interactions: typically ~80–150 lines total.

--- a/.agents/skills/write-product-spec/SKILL.md
+++ b/.agents/skills/write-product-spec/SKILL.md
@@ -30,7 +30,7 @@ If the artifact set has not been chosen, use `spec-driven-implementation` to dec
 - Does it contain decisions that a product/design stakeholder, public consumer, or owner of a deliberately stable cross-team contract should review?
 - Will it be an independent source of truth, rather than a less precise duplicate of `TECH.md` and its test plan?
 
-Use the answers to focus the requested document on its independently valuable consumer decisions. Do not use this skill to recommend replacing or removing a directly requested `PRODUCT.md`.
+Use the answers to focus the requested document on its independently valuable consumer decisions. Keep this skill focused on producing and right-sizing the requested `PRODUCT.md`; artifact selection belongs to `spec-driven-implementation`.
 
 Write specs to `specs/<id>/PRODUCT.md`, where `<id>` is one of:
 
@@ -115,7 +115,7 @@ If you find yourself writing the same idea in Summary, Problem, Goals, and Behav
 
 Approved specs may ship in the same PR as the implementation. As implementation evolves, update `PRODUCT.md` in the same PR when user-facing behavior, UX details, public contracts, or deliberately stable cross-team contracts change. The checked-in spec should describe the feature that actually ships.
 
-If evolving design changes the document's value, keep `PRODUCT.md` current for its approved behavior and surface any proposed artifact-set change through `spec-driven-implementation` rather than consolidating, removing, or reclassifying it here. Surface material behavior changes for re-review; routine edits that keep the approved intent current do not require renewed approval.
+If evolving design changes the document's value, keep `PRODUCT.md` current for its approved behavior and return to `spec-driven-implementation` to revisit artifact selection. Surface material behavior changes for re-review; routine edits that keep the approved intent current do not require renewed approval.
 
 For large features, the implementer may optionally keep a `DECISIONS.md` file summarizing concrete decisions made during design and implementation. Offer it when it would help future agents; otherwise skip it.
 

--- a/.agents/skills/write-tech-spec/SKILL.md
+++ b/.agents/skills/write-tech-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-tech-spec
-description: Writes an implementation-oriented TECH.md for significant features, hardening, bug fixes, or refactors after researching the current codebase and implementation constraints. Use when the user asks for a technical spec, implementation plan, or architecture doc.
+description: Writes an implementation-oriented TECH.md spec. Use when the user asks for a technical spec, implementation plan, architecture document, or technical design.
 ---
 
 # write-tech-spec
@@ -21,11 +21,13 @@ Match the id used by the sibling `PRODUCT.md` when one exists. `specs/` should c
 
 Ticket / issue references are optional. If the user has a Linear ticket or GitHub issue, use its id. If they don't, ask them for a feature name to use as the directory. Only create a new Linear ticket or GitHub issue when the user explicitly asks for one; in that case use the Linear MCP tools or `gh` CLI respectively (and `ask_user_question` if team, labels, or repo are unclear).
 
-## When to use
+## Right-size `TECH.md` around its independent value
 
-Use this skill when the implementation spans multiple modules, has meaningful architectural tradeoffs, or when reviewers will benefit from seeing the plan before or alongside the code. For pure UI changes or straightforward fixes, a tech spec is often unnecessary.
+If the artifact set has not been chosen, use `spec-driven-implementation` to decide which specs add value. When the user directly asks for `TECH.md`, honor that choice. Right-size the requested document to the amount of technical ambiguity, risk, and implementation detail that reviewers need: a local change using established patterns can be brief, while cross-cutting work or meaningful tradeoffs warrant more detail.
 
-Use an existing `PRODUCT.md` when it captures meaningful consumer-behavior decisions. For internal hardening, bug fixes, refactors, migrations, or other work that preserves relevant consumer semantics, prefer a standalone `TECH.md` with short `Technical safety and preservation guarantees`. Do not infer preservation from the task label: state in one sentence whether user-visible, public, and deliberately stable cross-team consumer semantics — including failure and recovery behavior — remain unchanged. If the implementation is still too uncertain, build an e2e prototype first and then write the tech spec from what was learned.
+Use every approved companion spec as input. When no `PRODUCT.md` exists, include concise `Technical safety and preservation guarantees` that capture the intended outcome and safety boundary. Do not use this skill to create, replace, consolidate, remove, or reclassify companion specs.
+
+If the implementation is too uncertain to specify accurately, recommend an e2e prototype before finalizing `TECH.md` rather than skipping the requested document.
 
 ## Research before writing
 
@@ -71,7 +73,7 @@ Optional sections — include only when they add signal. Omit the heading entire
 
 Right-size the spec to the feature:
 
-- Single-file change with clear approach: skip the tech spec or keep it under ~40 lines.
+- Single-file change with clear approach: keep the requested tech spec under ~40 lines.
 - Multi-module change with some ambiguity: target ~80–150 lines.
 - Large cross-cutting or architecturally novel change: longer is fine when every section earns its place.
 
@@ -84,7 +86,7 @@ If Context and Proposed changes end up describing the same files and state from 
 - Prefer concrete implementation guidance over generic architecture language.
 - Explain why the proposed design fits this repo.
 - Reference `PRODUCT.md` for meaningful consumer-behavior decisions when it exists. Keep Technical safety and preservation guarantees concise and stable, and do not translate every technical state or test case into guarantee language.
-- Do not create a redundant `PRODUCT.md` solely because the technical work is large or cross-cutting. If an approved product spec later becomes redundant, follow the governance below.
+- Treat every approved companion spec as input; artifact-set changes belong in `spec-driven-implementation`.
 - Each section should earn its place — if a section would repeat another or contain only boilerplate, omit it.
 
 ## Keep the spec current

--- a/.agents/skills/write-tech-spec/SKILL.md
+++ b/.agents/skills/write-tech-spec/SKILL.md
@@ -89,11 +89,15 @@ If Context and Proposed changes end up describing the same files and state from 
 - Treat every approved companion spec as input; artifact-set changes belong in `spec-driven-implementation`.
 - Each section should earn its place — if a section would repeat another or contain only boilerplate, omit it.
 
+## Approval handoff
+
+After drafting, present a concise summary of the material decisions, important tradeoffs, and unresolved questions. When called by `spec-driven-implementation`, return this handoff so that workflow can coordinate approval across the selected specs. When called directly, ask the user or another explicitly identified human approver to resolve or explicitly defer every question that would affect implementation, then ask them to approve the spec or request revisions before it is treated as ready for implementation.
+
 ## Keep the spec current
 
 Approved specs may ship in the same PR as the implementation. Update `TECH.md` in the same PR when module boundaries, implementation sequencing, risks, validation strategy, or rollout assumptions change. The checked-in spec should describe the implementation that actually ships.
 
-Surface material design or contract changes for re-review. Treat the approved artifact set as settled while using this skill and return to `spec-driven-implementation` to revisit it; routine edits that keep the approved design current do not require renewed approval.
+Present proposed material design or contract changes to the user or another explicitly identified human approver and get explicit approval before updating the approved spec. Treat the approved artifact set as settled while using this skill and return to `spec-driven-implementation` to revisit it; routine edits that keep the approved design current do not require renewed approval.
 
 For large features, the implementer may optionally keep a `DECISIONS.md` file summarizing concrete decisions. Offer it when it would help future agents; otherwise skip it.
 

--- a/.agents/skills/write-tech-spec/SKILL.md
+++ b/.agents/skills/write-tech-spec/SKILL.md
@@ -25,7 +25,7 @@ Ticket / issue references are optional. If the user has a Linear ticket or GitHu
 
 If the artifact set has not been chosen, use `spec-driven-implementation` to decide which specs add value. When the user directly asks for `TECH.md`, honor that choice. Right-size the requested document to the amount of technical ambiguity, risk, and implementation detail that reviewers need: a local change using established patterns can be brief, while cross-cutting work or meaningful tradeoffs warrant more detail.
 
-Use every approved companion spec as input. When no `PRODUCT.md` exists, include concise `Technical safety and preservation guarantees` that capture the intended outcome and safety boundary. Do not use this skill to create, replace, consolidate, remove, or reclassify companion specs.
+Use every approved companion spec as input. When no `PRODUCT.md` exists, include concise `Technical safety and preservation guarantees` that capture the intended outcome and safety boundary. Keep this skill focused on the requested `TECH.md`; `spec-driven-implementation` owns artifact selection.
 
 If the implementation is too uncertain to specify accurately, recommend an e2e prototype before finalizing `TECH.md` rather than skipping the requested document.
 
@@ -93,7 +93,7 @@ If Context and Proposed changes end up describing the same files and state from 
 
 Approved specs may ship in the same PR as the implementation. Update `TECH.md` in the same PR when module boundaries, implementation sequencing, risks, validation strategy, or rollout assumptions change. The checked-in spec should describe the implementation that actually ships.
 
-Surface material design or contract changes for re-review. Do not delete or reclassify an approved spec without explicit confirmation from the user or accountable spec owner; routine edits that keep the approved design current do not require renewed approval.
+Surface material design or contract changes for re-review. Treat the approved artifact set as settled while using this skill and return to `spec-driven-implementation` to revisit it; routine edits that keep the approved design current do not require renewed approval.
 
 For large features, the implementer may optionally keep a `DECISIONS.md` file summarizing concrete decisions. Offer it when it would help future agents; otherwise skip it.
 

--- a/.agents/skills/write-tech-spec/SKILL.md
+++ b/.agents/skills/write-tech-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-tech-spec
-description: Writes a TECH.md spec for significant features, hardening, bug fixes, or refactors after researching the current codebase and implementation constraints. Use when the user asks for a technical spec, implementation plan, or architecture doc; supports either a companion PRODUCT.md or a standalone TECH.md with concise technical safety and preservation guarantees.
+description: Writes an implementation-oriented TECH.md for significant features, hardening, bug fixes, or refactors after researching the current codebase and implementation constraints. Use when the user asks for a technical spec, implementation plan, or architecture doc.
 ---
 
 # write-tech-spec

--- a/.agents/skills/write-tech-spec/SKILL.md
+++ b/.agents/skills/write-tech-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-tech-spec
-description: Writes a TECH.md spec for significant features, hardening, bug fixes, or refactors after researching the current codebase and implementation constraints. Use when the user asks for a technical spec, implementation plan, or architecture doc; supports either a companion PRODUCT.md or a standalone TECH.md with concise behavioral guarantees.
+description: Writes a TECH.md spec for significant features, hardening, bug fixes, or refactors after researching the current codebase and implementation constraints. Use when the user asks for a technical spec, implementation plan, or architecture doc; supports either a companion PRODUCT.md or a standalone TECH.md with concise technical safety and preservation guarantees.
 ---
 
 # write-tech-spec
@@ -25,7 +25,7 @@ Ticket / issue references are optional. If the user has a Linear ticket or GitHu
 
 Use this skill when the implementation spans multiple modules, has meaningful architectural tradeoffs, or when reviewers will benefit from seeing the plan before or alongside the code. For pure UI changes or straightforward fixes, a tech spec is often unnecessary.
 
-Use an existing `PRODUCT.md` when it captures meaningful product behavior decisions. For internal hardening, bug fixes, refactors, migrations, or other work that preserves existing product semantics, prefer a standalone `TECH.md` with a short `Behavioral guarantees` section. If the implementation is still too uncertain, build an e2e prototype first and then write the tech spec from what was learned.
+Use an existing `PRODUCT.md` when it captures meaningful consumer-behavior decisions. For internal hardening, bug fixes, refactors, migrations, or other work that preserves relevant consumer semantics, prefer a standalone `TECH.md` with short `Technical safety and preservation guarantees`. Do not infer preservation from the task label: state in one sentence whether user-visible, public, and deliberately stable cross-team consumer semantics — including failure and recovery behavior — remain unchanged. If the implementation is still too uncertain, build an e2e prototype first and then write the tech spec from what was learned.
 
 ## Research before writing
 
@@ -36,14 +36,17 @@ When referencing relevant code chunks in the spec, prefer commit-pinned referenc
 
 Required sections:
 
-1. **Behavioral guarantees** — Required only when there is no companion `PRODUCT.md`. Capture roughly 3–8 stable, reviewable guarantees that define the intended outcome and safety boundary without duplicating the technical transition matrix or test plan. For hardening and bug fixes, these often state that normal behavior remains unchanged, important state/data is preserved, recovery is conservative, and malformed or unsupported inputs cannot corrupt trustworthy state.
-2. **Context** — What's being built, how the current system works in the area being changed, and the most relevant files with line references. Combine the "problem," "current state," and "relevant code" into one grounded section. Example references:
+1. **Context** — What's being built, how the current system works in the area being changed, and the most relevant files with line references. Combine the "problem," "current state," and "relevant code" into one grounded section. Example references:
    - [`app/src/workspace/mod.rs:42 @ <commit-sha>`](https://github.com/warpdotdev/warp/blob/<commit-sha>/app/src/workspace/mod.rs#L42) — entry point for the user flow
    - [`app/src/workspace/workspace.rs (120-220) @ <commit-sha>`](https://github.com/warpdotdev/warp/blob/<commit-sha>/app/src/workspace/workspace.rs#L120-L220) — state and event handling that will likely change
-   Reference `PRODUCT.md` for user-visible behavior when it exists; otherwise use the standalone Behavioral guarantees above.
-3. **Proposed changes** — The implementation plan: which modules change, new types/APIs/state being introduced, data flow, ownership boundaries, and how the design follows existing patterns. Call out tradeoffs when there is more than one reasonable path.
-4. **Testing and validation** — How the implementation will be verified against the intended behavior and technical risks. Owns everything about proving the change works: unit tests, integration tests, manual steps, screenshots, videos, and any other verification. Map important validation to the companion product behavior or standalone behavioral guarantees without restating either as a second exhaustive matrix.
-5. **Parallelization** — Actively evaluate whether parallel sub-agents (launched via `run_agents`) would meaningfully reduce wall-clock time or isolate work. Skip this section if `run_agents` is not available. When the spec proposes using sub-agents, include for each proposed agent:
+   Reference `PRODUCT.md` for consumer behavior when it exists; otherwise use the standalone Technical safety and preservation guarantees described below.
+2. **Proposed changes** — The implementation plan: which modules change, new types/APIs/state being introduced, data flow, ownership boundaries, and how the design follows existing patterns. Call out tradeoffs when there is more than one reasonable path.
+3. **Testing and validation** — How the implementation will be verified against the intended behavior and technical risks. Owns everything about proving the change works: unit tests, integration tests, manual steps, screenshots, videos, and any other verification. Map each important technical guarantee and relevant product behavior to at least one concrete verification step without restating either as a second exhaustive matrix.
+
+Conditionally required sections:
+
+- **Technical safety and preservation guarantees** — Required when there is no companion `PRODUCT.md`; include it alongside `PRODUCT.md` when independently valuable technical guarantees remain. Capture roughly 3–8 stable, reviewable guarantees that define the outcome-preservation and safety boundary without duplicating product Behavior, the technical transition matrix, or the test plan. For hardening and bug fixes, these often state that normal consumer behavior remains unchanged, important state/data is preserved, recovery is conservative, and malformed or unsupported inputs cannot corrupt trustworthy state.
+- **Parallelization** — Include when `run_agents` is available. Actively evaluate whether parallel sub-agents would meaningfully reduce wall-clock time or isolate work. When the spec proposes using sub-agents, include for each proposed agent:
    - A short name/role and the subtask it owns.
    - Execution mode (`local` or `remote`) with a one-line rationale.
    - For local agents: the working directory or git worktree it should use, so parallel agents do not collide on the same checkout or files.
@@ -80,13 +83,15 @@ If Context and Proposed changes end up describing the same files and state from 
 - Pin important code references to a commit SHA and link them to the corresponding GitHub lines when the repository has an accessible remote.
 - Prefer concrete implementation guidance over generic architecture language.
 - Explain why the proposed design fits this repo.
-- Reference `PRODUCT.md` for behavior when it exists. Otherwise keep Behavioral guarantees concise and stable rather than translating every technical state or test case into product language.
-- Do not create or preserve a redundant `PRODUCT.md` solely because the technical work is large or cross-cutting.
+- Reference `PRODUCT.md` for meaningful consumer-behavior decisions when it exists. Keep Technical safety and preservation guarantees concise and stable, and do not translate every technical state or test case into guarantee language.
+- Do not create a redundant `PRODUCT.md` solely because the technical work is large or cross-cutting. If an approved product spec later becomes redundant, follow the governance below.
 - Each section should earn its place — if a section would repeat another or contain only boilerplate, omit it.
 
 ## Keep the spec current
 
 Approved specs may ship in the same PR as the implementation. Update `TECH.md` in the same PR when module boundaries, implementation sequencing, risks, validation strategy, or rollout assumptions change. The checked-in spec should describe the implementation that actually ships.
+
+Surface material design or contract changes for re-review. Do not delete or reclassify an approved spec without explicit confirmation from the user or accountable spec owner; routine edits that keep the approved design current do not require renewed approval.
 
 For large features, the implementer may optionally keep a `DECISIONS.md` file summarizing concrete decisions. Offer it when it would help future agents; otherwise skip it.
 

--- a/.agents/skills/write-tech-spec/SKILL.md
+++ b/.agents/skills/write-tech-spec/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: write-tech-spec
-description: Write a TECH.md spec for a significant Warp feature after researching the current codebase and implementation constraints. Use when the user asks for a technical spec, implementation plan, or architecture doc tied to a product spec.
+description: Writes a TECH.md spec for significant features, hardening, bug fixes, or refactors after researching the current codebase and implementation constraints. Use when the user asks for a technical spec, implementation plan, or architecture doc; supports either a companion PRODUCT.md or a standalone TECH.md with concise behavioral guarantees.
 ---
 
 # write-tech-spec
 
-Write a `TECH.md` spec for a significant feature in Warp.
+Write a `TECH.md` spec for significant technical work in Warp.
 
 ## Overview
 
-The tech spec should translate product intent into an implementation plan that fits the existing codebase, documents architectural choices, and makes the work easier for agents to execute and reviewers to evaluate.
+The tech spec should translate the desired outcome into an implementation plan that fits the existing codebase, documents architectural choices, and makes the work easier for agents to execute and reviewers to evaluate. It may stand alone or accompany `PRODUCT.md`; do not create a product spec merely to anchor a technical design.
 
 Write specs to `specs/<id>/TECH.md`, where `<id>` is one of:
 
@@ -25,7 +25,7 @@ Ticket / issue references are optional. If the user has a Linear ticket or GitHu
 
 Use this skill when the implementation spans multiple modules, has meaningful architectural tradeoffs, or when reviewers will benefit from seeing the plan before or alongside the code. For pure UI changes or straightforward fixes, a tech spec is often unnecessary.
 
-Prefer to have a `PRODUCT.md` first so the technical plan is anchored to agreed behavior. If the implementation is still too uncertain, build an e2e prototype first and then write the tech spec from what was learned.
+Use an existing `PRODUCT.md` when it captures meaningful product behavior decisions. For internal hardening, bug fixes, refactors, migrations, or other work that preserves existing product semantics, prefer a standalone `TECH.md` with a short `Behavioral guarantees` section. If the implementation is still too uncertain, build an e2e prototype first and then write the tech spec from what was learned.
 
 ## Research before writing
 
@@ -36,13 +36,14 @@ When referencing relevant code chunks in the spec, prefer commit-pinned referenc
 
 Required sections:
 
-1. **Context** — What's being built, how the current system works in the area being changed, and the most relevant files with line references. Combine the "problem," "current state," and "relevant code" into one grounded section. Example references:
+1. **Behavioral guarantees** — Required only when there is no companion `PRODUCT.md`. Capture roughly 3–8 stable, reviewable guarantees that define the intended outcome and safety boundary without duplicating the technical transition matrix or test plan. For hardening and bug fixes, these often state that normal behavior remains unchanged, important state/data is preserved, recovery is conservative, and malformed or unsupported inputs cannot corrupt trustworthy state.
+2. **Context** — What's being built, how the current system works in the area being changed, and the most relevant files with line references. Combine the "problem," "current state," and "relevant code" into one grounded section. Example references:
    - [`app/src/workspace/mod.rs:42 @ <commit-sha>`](https://github.com/warpdotdev/warp/blob/<commit-sha>/app/src/workspace/mod.rs#L42) — entry point for the user flow
    - [`app/src/workspace/workspace.rs (120-220) @ <commit-sha>`](https://github.com/warpdotdev/warp/blob/<commit-sha>/app/src/workspace/workspace.rs#L120-L220) — state and event handling that will likely change
-   Reference `PRODUCT.md` for user-visible behavior rather than restating it.
-2. **Proposed changes** — The implementation plan: which modules change, new types/APIs/state being introduced, data flow, ownership boundaries, and how the design follows existing patterns. Call out tradeoffs when there is more than one reasonable path.
-3. **Testing and validation** — How the implementation will be verified against the product behavior. Owns everything about proving the feature works: unit tests, integration tests, manual steps, screenshots, videos, and any other verification. Reference the numbered Behavior invariants from `PRODUCT.md` directly rather than restating them; each important invariant should map to a concrete test or verification step. This section is where validation lives — `PRODUCT.md` intentionally does not have a Validation section.
-4. **Parallelization** — Actively evaluate whether parallel sub-agents (launched via `run_agents`) would meaningfully reduce wall-clock time or isolate work. Skip this section if `run_agents` is not available. When the spec proposes using sub-agents, include for each proposed agent:
+   Reference `PRODUCT.md` for user-visible behavior when it exists; otherwise use the standalone Behavioral guarantees above.
+3. **Proposed changes** — The implementation plan: which modules change, new types/APIs/state being introduced, data flow, ownership boundaries, and how the design follows existing patterns. Call out tradeoffs when there is more than one reasonable path.
+4. **Testing and validation** — How the implementation will be verified against the intended behavior and technical risks. Owns everything about proving the change works: unit tests, integration tests, manual steps, screenshots, videos, and any other verification. Map important validation to the companion product behavior or standalone behavioral guarantees without restating either as a second exhaustive matrix.
+5. **Parallelization** — Actively evaluate whether parallel sub-agents (launched via `run_agents`) would meaningfully reduce wall-clock time or isolate work. Skip this section if `run_agents` is not available. When the spec proposes using sub-agents, include for each proposed agent:
    - A short name/role and the subtask it owns.
    - Execution mode (`local` or `remote`) with a one-line rationale.
    - For local agents: the working directory or git worktree it should use, so parallel agents do not collide on the same checkout or files.
@@ -79,7 +80,8 @@ If Context and Proposed changes end up describing the same files and state from 
 - Pin important code references to a commit SHA and link them to the corresponding GitHub lines when the repository has an accessible remote.
 - Prefer concrete implementation guidance over generic architecture language.
 - Explain why the proposed design fits this repo.
-- Reference `PRODUCT.md` for behavior instead of restating it.
+- Reference `PRODUCT.md` for behavior when it exists. Otherwise keep Behavioral guarantees concise and stable rather than translating every technical state or test case into product language.
+- Do not create or preserve a redundant `PRODUCT.md` solely because the technical work is large or cross-cutting.
 - Each section should earn its place — if a section would repeat another or contain only boilerplate, omit it.
 
 ## Keep the spec current

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Each skill lives in its own directory under `.agents/skills/`. The only required
 
 ### Spec workflow
 
-- `write-product-spec` — writes user-facing `PRODUCT.md` specs.
-- `write-tech-spec` — writes implementation-oriented `TECH.md` specs.
-- `spec-driven-implementation` — guides the full spec-first workflow for substantial features.
-- `implement-specs` — implements approved `PRODUCT.md` and `TECH.md` files while keeping specs and code aligned.
+- `write-product-spec` — writes `PRODUCT.md` only for independently valuable consumer-behavior decisions.
+- `write-tech-spec` — writes standalone or companion implementation-oriented `TECH.md` specs.
+- `spec-driven-implementation` — chooses pragmatically among no spec, `PRODUCT.md` only, `TECH.md` only, or both.
+- `implement-specs` — implements whichever approved specs exist while keeping specs and code aligned.
 
 ### Development workflow
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Each skill lives in its own directory under `.agents/skills/`. The only required
 
 ### Spec workflow
 
-- `write-product-spec` — writes `PRODUCT.md` only for independently valuable consumer-behavior decisions.
-- `write-tech-spec` — writes standalone or companion implementation-oriented `TECH.md` specs.
-- `spec-driven-implementation` — chooses pragmatically among no spec, `PRODUCT.md` only, `TECH.md` only, or both.
-- `implement-specs` — implements whichever approved specs exist while keeping specs and code aligned.
+- `write-product-spec` — writes consumer-behavior-focused `PRODUCT.md` specs.
+- `write-tech-spec` — writes implementation-oriented `TECH.md` specs.
+- `spec-driven-implementation` — guides the workflow for deciding, writing, approving, and implementing valuable specs.
+- `implement-specs` — implements approved `PRODUCT.md` and/or `TECH.md` specs while keeping specs and code aligned.
 
 ### Development workflow
 


### PR DESCRIPTION
## Description
The previous spec workflow could encourage redundant product specs for technically complex work, blur responsibility between selecting, writing, implementing, and validating specs, and leave approval boundaries implicit. That made it harder for humans and agents to align on an approved solution and keep the durable documentation synchronized with implementation.

This PR establishes a pragmatic workflow where `spec-driven-implementation` selects the smallest independently valuable artifact set: no spec, `PRODUCT.md` only, `TECH.md` only, or both. Direct writer skills honor and right-size requested documents, while implementation consumes the settled artifact set and all approved commitments regardless of which spec contains them.

The workflow now requires explicit human approval for the artifact path and drafted specs, requires implementation-blocking questions to be resolved or explicitly deferred, and requires approval before proposed material changes are persisted or acted upon. Validation also reads relevant approved sibling specs and distinguishes authoritative commitments from supporting context based on approval evidence rather than filenames alone.

## Testing
- Ran multiple model-diverse council reviews, including cross-critique, and incorporated convergent findings and subsequent reviewer feedback.
- Ran local approval-boundary, material-change, responsibility-boundary, frontmatter, terminology, whitespace, and changed-file scope validation.
- Ran `git diff --check`.
- Skill/documentation-only change; no code tests were run.

Co-Authored-By: Oz <oz-agent@warp.dev>
