### PR TITLE
docs(review-pr): add false-positive rules from warp-server feedback

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -26,6 +26,8 @@ Review the current pull request and write the output to `review.json`.
 - If a concern involves untouched code, mention it in top-level `body` instead of an inline comment.
 - Do not suggest adding test cases that only vary constructor inputs or struct fields when the existing test already covers the meaningful behavior. Only suggest new tests when they exercise a distinct code path or edge case.
 - When a PR is clearly a V0 or initial implementation, frame robustness suggestions (timeouts, retries, lifecycle management) as optional future work rather than blocking concerns, unless they risk correctness, security, or data loss.
+- Before claiming code is broken based on language, runtime, or database semantics (for example, what a SQL function, type, or built-in permits), confirm the behavior. A confident `CRITICAL`/`IMPORTANT` comment whose proposed fix is itself wrong is worse than no comment. When you are unsure, lower the severity and describe the risk instead of prescribing a concrete fix.
+- Keep your comments mutually consistent within a single review. Do not propose a change in one comment that contradicts another comment in the same review (for example, telling the author to remove a construct in one place and to add it back in another).
 
 ## Repository-specific guidance
 


### PR DESCRIPTION
## What

Adds two evidence-backed false-positive rules to the `review-pr` skill's **Review Scope**, derived from human feedback on agent-authored review comments.

## Why

Ran the warp-server `update-pr-review` workflow over the last 7 days of `oz-for-oss` review comments on `warpdotdev/warp-server` PRs (15 agent comments that received human replies; all on code PRs). Most comments were validated by maintainers, but one recurring failure mode stood out:

- **warp-server PR #11910** (3 review threads): the bot asserted incorrect PostgreSQL semantics around `chr(0)` / NUL bytes and proposed a `replace(..., chr(0), '')` fix that would have *guaranteed* a query failure (`chr(0)` itself raises `null character not permitted`). Worse, those suggestions **contradicted the bot's own earlier, correct comment** in the same review asking to remove `chr(0)`. The maintainer had to rebut the same point twice.

## Changes

Two new bullets in `.agents/skills/review-pr/SKILL.md`:

1. Verify language/runtime/database semantics before claiming code is broken; a confident `CRITICAL`/`IMPORTANT` comment with a wrong fix is worse than no comment. Lower severity and describe the risk when unsure rather than prescribing a concrete fix.
2. Keep comments mutually consistent within a single review (don't propose removing a construct in one comment and adding it back in another).

Spec PRs in the window had no agent review comments (only human-to-human design discussion), so `review-spec` is intentionally left unchanged.

cc @captainsafia

_Conversation: https://staging.warp.dev/conversation/a5946d89-3ced-4943-ba85-f2ef0ccd30be_
_Run: https://oz.staging.warp.dev/runs/019ee065-8132-7316-8773-a4abce136cd1_

_This PR was generated with [Oz](https://warp.dev/oz)._
