### PR TITLE
[common-skills migration] Add warp-skills install/remove wrappers + downstream lock refresh

### DIFF
--- a/.github/workflows/update-downstream-skill-locks.yml
+++ b/.github/workflows/update-downstream-skill-locks.yml
@@ -106,6 +106,8 @@ jobs:
       - name: Update target lockfile
         id: update
         run: |
+          # A consumer that has not adopted this lock (e.g. no warp-skills-lock.json)
+          # has nothing to refresh, so skip cleanly instead of failing the job.
           if [[ ! -f "target/${{ matrix.lock_file }}" ]]; then
             echo "::notice::target/${{ matrix.lock_file }} is absent in ${{ matrix.repository }}; nothing to refresh."
             echo "changed=false" >> "${GITHUB_OUTPUT}"
@@ -115,6 +117,8 @@ jobs:
             --repo-root target \
             --source "${{ matrix.source }}" \
             --lock-file "${{ matrix.lock_file }}"
+          # Detect whether regenerating the lock changed it vs the committed file;
+          # only a real change warrants opening a downstream PR.
           if git -C target diff --quiet -- "${{ matrix.lock_file }}"; then
             echo "changed=false" >> "${GITHUB_OUTPUT}"
           else

--- a/.github/workflows/update-downstream-skill-locks.yml
+++ b/.github/workflows/update-downstream-skill-locks.yml
@@ -1,4 +1,4 @@
-name: Update downstream common-skills lockfiles
+name: Update downstream skills lockfiles
 
 on:
   push:
@@ -11,18 +11,42 @@ permissions:
 
 jobs:
   update-lockfile:
-    name: Update ${{ matrix.repository }}
+    name: Update ${{ matrix.lock_label }} in ${{ matrix.repository }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
+          # common-skills lock (skills-lock.json) in each downstream consumer.
           - repository: warpdotdev/warp
             repository_name: warp
             base_branch: master
+            source: warpdotdev/common-skills
+            lock_file: skills-lock.json
+            lock_label: common skills
+            branch_prefix: common-skills-lock
           - repository: warpdotdev/warp-server
             repository_name: warp-server
             base_branch: develop
+            source: warpdotdev/common-skills
+            lock_file: skills-lock.json
+            lock_label: common skills
+            branch_prefix: common-skills-lock
+          # warp-skills lock (warp-skills-lock.json) in each downstream consumer.
+          - repository: warpdotdev/warp
+            repository_name: warp
+            base_branch: master
+            source: warpdotdev/warp-skills
+            lock_file: warp-skills-lock.json
+            lock_label: warp-skills
+            branch_prefix: warp-skills-lock
+          - repository: warpdotdev/warp-server
+            repository_name: warp-server
+            base_branch: develop
+            source: warpdotdev/warp-skills
+            lock_file: warp-skills-lock.json
+            lock_label: warp-skills
+            branch_prefix: warp-skills-lock
     steps:
       - name: Check out common-skills
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -63,8 +87,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.COMMON_SKILLS_SYNC_APP_ID }}
-          private-key: ${{ secrets.COMMON_SKILLS_SYNC_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.SKILLS_SYNC_APP_ID }}
+          private-key: ${{ secrets.SKILLS_SYNC_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ matrix.repository_name }}
           permission-contents: write
@@ -82,8 +106,16 @@ jobs:
       - name: Update target lockfile
         id: update
         run: |
-          common-skills/scripts/update_common_skills_lock --repo-root target
-          if git -C target diff --quiet -- skills-lock.json; then
+          if [[ ! -f "target/${{ matrix.lock_file }}" ]]; then
+            echo "::notice::target/${{ matrix.lock_file }} is absent in ${{ matrix.repository }}; nothing to refresh."
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          common-skills/scripts/update_common_skills_lock \
+            --repo-root target \
+            --source "${{ matrix.source }}" \
+            --lock-file "${{ matrix.lock_file }}"
+          if git -C target diff --quiet -- "${{ matrix.lock_file }}"; then
             echo "changed=false" >> "${GITHUB_OUTPUT}"
           else
             echo "changed=true" >> "${GITHUB_OUTPUT}"
@@ -96,172 +128,20 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           path: target
-          add-paths: skills-lock.json
+          add-paths: ${{ matrix.lock_file }}
           base: ${{ matrix.base_branch }}
-          branch: automation/common-skills-lock-${{ github.sha }}
+          branch: automation/${{ matrix.branch_prefix }}-${{ github.sha }}
           delete-branch: true
-          commit-message: Update common skills lock for ${{ steps.source.outputs.label }}
-          title: Update common skills lock for ${{ steps.source.outputs.label }}
+          commit-message: Update ${{ matrix.lock_label }} lock for ${{ steps.source.outputs.label }}
+          title: Update ${{ matrix.lock_label }} lock for ${{ steps.source.outputs.label }}
           body: |
             ## Description
 
-            Updates `skills-lock.json` to distribute the common skills from [${{ steps.source.outputs.label }}](${{ steps.source.outputs.url }}).
+            Updates `${{ matrix.lock_file }}` to distribute the ${{ matrix.lock_label }} from [${{ steps.source.outputs.label }}](${{ steps.source.outputs.url }}).
 
             ## Testing
 
-            Generated with `scripts/update_common_skills_lock`.
-
-      - name: Request source author as reviewer
-        if: steps.create-pr.outputs.pull-request-number != '' && steps.source.outputs.author != ''
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PULL_REQUEST_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
-          REVIEWER: ${{ steps.source.outputs.author }}
-          TARGET_REPOSITORY: ${{ matrix.repository }}
-        run: |
-          if gh api \
-            --method POST \
-            "repos/${TARGET_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}/requested_reviewers" \
-            -f "reviewers[]=${REVIEWER}" >/dev/null; then
-            echo "Requested ${REVIEWER} as reviewer."
-          else
-            echo "::warning::Could not request ${REVIEWER} as reviewer; the pull request remains open."
-          fi
-
-      - name: Enable squash auto-merge
-        if: steps.create-pr.outputs.pull-request-number != ''
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PULL_REQUEST_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
-          TARGET_REPOSITORY: ${{ matrix.repository }}
-        run: gh pr merge "${PULL_REQUEST_NUMBER}" --repo "${TARGET_REPOSITORY}" --auto --squash
-
-  update-warp-skills-lockfile:
-    name: Update warp-skills lock in ${{ matrix.repository }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - repository: warpdotdev/warp
-            repository_name: warp
-            base_branch: master
-          - repository: warpdotdev/warp-server
-            repository_name: warp-server
-            base_branch: develop
-    steps:
-      - name: Resolve source pull request
-        id: source
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SOURCE_REPOSITORY: ${{ github.repository }}
-          SOURCE_SHA: ${{ github.sha }}
-        run: |
-          source_pr="$(
-            gh api "repos/${SOURCE_REPOSITORY}/commits/${SOURCE_SHA}/pulls" \
-              --jq '[.[] | select(.merged_at != null and .base.ref == "main")][0] // {}'
-          )"
-          source_pr_number="$(jq -r '.number // empty' <<< "${source_pr}")"
-          source_pr_author="$(jq -r '.user.login // empty' <<< "${source_pr}")"
-          source_pr_url="$(jq -r '.html_url // empty' <<< "${source_pr}")"
-
-          if [[ -n "${source_pr_number}" ]]; then
-            {
-              echo "author=${source_pr_author}"
-              echo "label=warpdotdev/common-skills#${source_pr_number}"
-              echo "url=${source_pr_url}"
-            } >> "${GITHUB_OUTPUT}"
-          else
-            {
-              echo "author="
-              echo "label=${SOURCE_SHA}"
-              echo "url=https://github.com/${SOURCE_REPOSITORY}/commit/${SOURCE_SHA}"
-            } >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Generate target GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ vars.COMMON_SKILLS_SYNC_APP_ID }}
-          private-key: ${{ secrets.COMMON_SKILLS_SYNC_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ matrix.repository_name }}
-          permission-contents: write
-          permission-pull-requests: write
-
-      - name: Check out target repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: ${{ matrix.repository }}
-          ref: ${{ matrix.base_branch }}
-          path: target
-          token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
-
-      - name: Update target warp-skills lockfile
-        id: update
-        env:
-          SKILLS_CLI_VERSION: "1.5.6"
-          WARP_SKILLS_SOURCE: warpdotdev/warp-skills
-        run: |
-          lock_file="target/warp-skills-lock.json"
-          if [[ ! -f "${lock_file}" ]]; then
-            echo "::notice::${lock_file} is absent in ${{ matrix.repository }}; nothing to refresh."
-            echo "changed=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          work_dir="$(mktemp -d "${TMPDIR:-/tmp}/warp-skills-lock.XXXXXX")"
-          cp "${lock_file}" "${work_dir}/skills-lock.json"
-          git -C "${work_dir}" init --quiet
-          if ! (
-            cd "${work_dir}"
-            npx --yes "skills@${SKILLS_CLI_VERSION}" add "${WARP_SKILLS_SOURCE}" -a warp -s '*' -y --copy
-          ) < /dev/null; then
-            echo "::warning::Failed to regenerate warp-skills-lock.json from ${WARP_SKILLS_SOURCE}; skipping."
-            echo "changed=false" >> "${GITHUB_OUTPUT}"
-            rm -rf "${work_dir}"
-            exit 0
-          fi
-
-          if [[ ! -f "${work_dir}/skills-lock.json" ]]; then
-            echo "::warning::warp-skills update did not produce a candidate lockfile; skipping."
-            echo "changed=false" >> "${GITHUB_OUTPUT}"
-            rm -rf "${work_dir}"
-            exit 0
-          fi
-
-          if cmp -s "${lock_file}" "${work_dir}/skills-lock.json"; then
-            echo "warp-skills-lock.json is already up to date."
-            echo "changed=false" >> "${GITHUB_OUTPUT}"
-          else
-            cp "${work_dir}/skills-lock.json" "${lock_file}"
-            echo "changed=true" >> "${GITHUB_OUTPUT}"
-          fi
-          rm -rf "${work_dir}"
-
-      - name: Create downstream pull request
-        if: steps.update.outputs.changed == 'true'
-        id: create-pr
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          path: target
-          add-paths: warp-skills-lock.json
-          base: ${{ matrix.base_branch }}
-          branch: automation/warp-skills-lock-${{ github.sha }}
-          delete-branch: true
-          commit-message: Update warp-skills lock for ${{ steps.source.outputs.label }}
-          title: Update warp-skills lock for ${{ steps.source.outputs.label }}
-          body: |
-            ## Description
-
-            Refreshes `warp-skills-lock.json` from [warpdotdev/warp-skills](https://github.com/warpdotdev/warp-skills), alongside the common skills lock from [${{ steps.source.outputs.label }}](${{ steps.source.outputs.url }}).
-
-            ## Testing
-
-            Regenerated with the `skills` CLI against `warpdotdev/warp-skills`.
+            Generated with `scripts/update_common_skills_lock --source ${{ matrix.source }} --lock-file ${{ matrix.lock_file }}`.
 
       - name: Request source author as reviewer
         if: steps.create-pr.outputs.pull-request-number != '' && steps.source.outputs.author != ''

--- a/.github/workflows/update-downstream-skill-locks.yml
+++ b/.github/workflows/update-downstream-skill-locks.yml
@@ -87,8 +87,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SKILLS_SYNC_APP_ID }}
-          private-key: ${{ secrets.SKILLS_SYNC_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.COMMON_SKILLS_SYNC_APP_ID }}
+          private-key: ${{ secrets.COMMON_SKILLS_SYNC_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ matrix.repository_name }}
           permission-contents: write

--- a/.github/workflows/update-downstream-skill-locks.yml
+++ b/.github/workflows/update-downstream-skill-locks.yml
@@ -135,3 +135,155 @@ jobs:
           PULL_REQUEST_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
           TARGET_REPOSITORY: ${{ matrix.repository }}
         run: gh pr merge "${PULL_REQUEST_NUMBER}" --repo "${TARGET_REPOSITORY}" --auto --squash
+
+  update-warp-skills-lockfile:
+    name: Update warp-skills lock in ${{ matrix.repository }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: warpdotdev/warp
+            repository_name: warp
+            base_branch: master
+          - repository: warpdotdev/warp-server
+            repository_name: warp-server
+            base_branch: develop
+    steps:
+      - name: Resolve source pull request
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REPOSITORY: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          source_pr="$(
+            gh api "repos/${SOURCE_REPOSITORY}/commits/${SOURCE_SHA}/pulls" \
+              --jq '[.[] | select(.merged_at != null and .base.ref == "main")][0] // {}'
+          )"
+          source_pr_number="$(jq -r '.number // empty' <<< "${source_pr}")"
+          source_pr_author="$(jq -r '.user.login // empty' <<< "${source_pr}")"
+          source_pr_url="$(jq -r '.html_url // empty' <<< "${source_pr}")"
+
+          if [[ -n "${source_pr_number}" ]]; then
+            {
+              echo "author=${source_pr_author}"
+              echo "label=warpdotdev/common-skills#${source_pr_number}"
+              echo "url=${source_pr_url}"
+            } >> "${GITHUB_OUTPUT}"
+          else
+            {
+              echo "author="
+              echo "label=${SOURCE_SHA}"
+              echo "url=https://github.com/${SOURCE_REPOSITORY}/commit/${SOURCE_SHA}"
+            } >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Generate target GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.COMMON_SKILLS_SYNC_APP_ID }}
+          private-key: ${{ secrets.COMMON_SKILLS_SYNC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ matrix.repository_name }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Check out target repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ matrix.repository }}
+          ref: ${{ matrix.base_branch }}
+          path: target
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Update target warp-skills lockfile
+        id: update
+        env:
+          SKILLS_CLI_VERSION: "1.5.6"
+          WARP_SKILLS_SOURCE: warpdotdev/warp-skills
+        run: |
+          lock_file="target/warp-skills-lock.json"
+          if [[ ! -f "${lock_file}" ]]; then
+            echo "::notice::${lock_file} is absent in ${{ matrix.repository }}; nothing to refresh."
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          work_dir="$(mktemp -d "${TMPDIR:-/tmp}/warp-skills-lock.XXXXXX")"
+          cp "${lock_file}" "${work_dir}/skills-lock.json"
+          git -C "${work_dir}" init --quiet
+          if ! (
+            cd "${work_dir}"
+            npx --yes "skills@${SKILLS_CLI_VERSION}" add "${WARP_SKILLS_SOURCE}" -a warp -s '*' -y --copy
+          ) < /dev/null; then
+            echo "::warning::Failed to regenerate warp-skills-lock.json from ${WARP_SKILLS_SOURCE}; skipping."
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+            rm -rf "${work_dir}"
+            exit 0
+          fi
+
+          if [[ ! -f "${work_dir}/skills-lock.json" ]]; then
+            echo "::warning::warp-skills update did not produce a candidate lockfile; skipping."
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+            rm -rf "${work_dir}"
+            exit 0
+          fi
+
+          if cmp -s "${lock_file}" "${work_dir}/skills-lock.json"; then
+            echo "warp-skills-lock.json is already up to date."
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+          else
+            cp "${work_dir}/skills-lock.json" "${lock_file}"
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+          fi
+          rm -rf "${work_dir}"
+
+      - name: Create downstream pull request
+        if: steps.update.outputs.changed == 'true'
+        id: create-pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          path: target
+          add-paths: warp-skills-lock.json
+          base: ${{ matrix.base_branch }}
+          branch: automation/warp-skills-lock-${{ github.sha }}
+          delete-branch: true
+          commit-message: Update warp-skills lock for ${{ steps.source.outputs.label }}
+          title: Update warp-skills lock for ${{ steps.source.outputs.label }}
+          body: |
+            ## Description
+
+            Refreshes `warp-skills-lock.json` from [warpdotdev/warp-skills](https://github.com/warpdotdev/warp-skills), alongside the common skills lock from [${{ steps.source.outputs.label }}](${{ steps.source.outputs.url }}).
+
+            ## Testing
+
+            Regenerated with the `skills` CLI against `warpdotdev/warp-skills`.
+
+      - name: Request source author as reviewer
+        if: steps.create-pr.outputs.pull-request-number != '' && steps.source.outputs.author != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PULL_REQUEST_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+          REVIEWER: ${{ steps.source.outputs.author }}
+          TARGET_REPOSITORY: ${{ matrix.repository }}
+        run: |
+          if gh api \
+            --method POST \
+            "repos/${TARGET_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}/requested_reviewers" \
+            -f "reviewers[]=${REVIEWER}" >/dev/null; then
+            echo "Requested ${REVIEWER} as reviewer."
+          else
+            echo "::warning::Could not request ${REVIEWER} as reviewer; the pull request remains open."
+          fi
+
+      - name: Enable squash auto-merge
+        if: steps.create-pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PULL_REQUEST_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+          TARGET_REPOSITORY: ${{ matrix.repository }}
+        run: gh pr merge "${PULL_REQUEST_NUMBER}" --repo "${TARGET_REPOSITORY}" --auto --squash

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,7 +3,7 @@ These scripts help consuming repositories install, remove, and verify shared age
 ## Files
 - `resolve_common_skills`: resolves and executes scripts from this directory, a local override directory, or raw GitHub.
 - `install_common_skills`: installs or updates common skills, then verifies the installed contents.
-- `update_common_skills_lock`: regenerates an existing common-skills lockfile without installing skills.
+- `update_common_skills_lock`: regenerates an existing skills lockfile without installing skills; accepts `--source`/`--lock-file` to target any skills source (e.g. `warp-skills-lock.json` from `warpdotdev/warp-skills`).
 - `remove_common_skills`: removes installed common skills from a selected target.
 ## Quick start
 Install common skills into the current checkout:
@@ -93,17 +93,19 @@ Successful install and skip paths verify that exactly one install target contain
 Project installs add local Git exclude entries for only the locked common-skill directories so unrelated project skills in `.agents/skills` remain visible to Git.
 Global installs are shared across client repositories. A second repo pinned to the same lock verifies and succeeds without unnecessarily reinstalling; a repo pinned to a different lock fails with a version-mismatch error instead of overwriting the shared global install.
 ## Update lock script
-`update_common_skills_lock` non-interactively regenerates an existing `skills-lock.json` from the default branch of `warpdotdev/common-skills` without installing skills into the target repository.
+`update_common_skills_lock` non-interactively regenerates an existing skills lockfile from the default branch of a skills source repo without installing skills into the target repository. By default it regenerates `skills-lock.json` from `warpdotdev/common-skills`; pass `--source <owner/repo>` and `--lock-file <name>` to regenerate another lock (e.g. `--source warpdotdev/warp-skills --lock-file warp-skills-lock.json`).
 It generates a candidate in a temporary Git repository, then copies back only a changed `skills-lock.json`. Generator failures and missing candidate output fail the command instead of retaining the existing lock.
 Run it from a consuming repository:
 ```sh
 /path/to/common-skills/scripts/update_common_skills_lock --repo-root /path/to/consumer
+# or, for the warp-skills lock:
+/path/to/common-skills/scripts/update_common_skills_lock --repo-root /path/to/consumer --source warpdotdev/warp-skills --lock-file warp-skills-lock.json
 ```
 The downstream lockfile update workflow uses this command before opening lockfile-only pull requests.
 ## Downstream lockfile workflow
-`.github/workflows/update-downstream-skill-locks.yml` runs after every push to `main` and opens lockfile-only pull requests against `warpdotdev/warp` and `warpdotdev/warp-server` when their locks change.
+`.github/workflows/update-downstream-skill-locks.yml` runs after every push to `main`. A single parametrized matrixed job refreshes both `skills-lock.json` (from `warpdotdev/common-skills`) and `warp-skills-lock.json` (from `warpdotdev/warp-skills`) in `warpdotdev/warp` and `warpdotdev/warp-server`, opening a lockfile-only pull request for each lock that changes.
 Each pull request requests the author of the originating common-skills pull request when possible and enables squash auto-merge. Direct pushes and authors who cannot review a target repository do not prevent pull request creation.
-The workflow requires a dedicated GitHub App installed on both downstream repositories with contents and pull-request write access. Configure its App ID as the `COMMON_SKILLS_SYNC_APP_ID` Actions variable and its private key as the `COMMON_SKILLS_SYNC_APP_PRIVATE_KEY` Actions secret in `common-skills`.
+The workflow requires a dedicated GitHub App installed on both downstream repositories with contents and pull-request write access. Configure its App ID as the `SKILLS_SYNC_APP_ID` Actions variable and its private key as the `SKILLS_SYNC_APP_PRIVATE_KEY` Actions secret in `common-skills`. (Renamed from `COMMON_SKILLS_SYNC_APP_ID`/`COMMON_SKILLS_SYNC_APP_PRIVATE_KEY` since the workflow now syncs both common-skills and warp-skills locks.)
 ## Remove script
 `remove_common_skills` removes common agent skills listed in `skills-lock.json`.
 The script supports:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -105,7 +105,7 @@ Consumers invoke it through the same resolver as common skills:
 ```sh
 ./script/resolve_common_skills install_warp_skills -- --repo-root "${REPO_ROOT}" --if-needed
 ```
-`--best-effort` installs a distinct skill set into an explicit target, so it does not apply the project-vs-global exclusivity check (a guard that keeps a *single* set from being installed in both places). This lets warp-skills install to the project while common skills live globally. warp-skills should avoid reusing common-skill names; the bypass ensures an incidental name collision does not block the install.
+warp-skills must not reuse common-skill names. The project-vs-global exclusivity check applies to every set: if a locked skill is found in both `.agents/skills` and `~/.agents/skills`, the install fails instead of silently placing the same name in two locations. Since warp-skills and common skills use distinct names, this check also surfaces any accidental naming collision between the two sets.
 ## Update lock script
 `update_common_skills_lock` non-interactively regenerates an existing skills lockfile from the default branch of a skills source repo without installing skills into the target repository. By default it regenerates `skills-lock.json` from `warpdotdev/common-skills`; pass `--source <owner/repo>` and `--lock-file <name>` to regenerate another lock (e.g. `--source warpdotdev/warp-skills --lock-file warp-skills-lock.json`).
 It generates a candidate in a temporary Git repository, then copies back only a changed `skills-lock.json`. Generator failures and missing candidate output fail the command instead of retaining the existing lock.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -119,7 +119,7 @@ The downstream lockfile update workflow uses this command before opening lockfil
 ## Downstream lockfile workflow
 `.github/workflows/update-downstream-skill-locks.yml` runs after every push to `main`. A single parametrized matrixed job refreshes both `skills-lock.json` (from `warpdotdev/common-skills`) and `warp-skills-lock.json` (from `warpdotdev/warp-skills`) in `warpdotdev/warp` and `warpdotdev/warp-server`, opening a lockfile-only pull request for each lock that changes.
 Each pull request requests the author of the originating common-skills pull request when possible and enables squash auto-merge. Direct pushes and authors who cannot review a target repository do not prevent pull request creation.
-The workflow requires a dedicated GitHub App installed on both downstream repositories with contents and pull-request write access. Configure its App ID as the `SKILLS_SYNC_APP_ID` Actions variable and its private key as the `SKILLS_SYNC_APP_PRIVATE_KEY` Actions secret in `common-skills`.
+The workflow requires a dedicated GitHub App installed on both downstream repositories with contents and pull-request write access. Configure its App ID as the `COMMON_SKILLS_SYNC_APP_ID` Actions variable and its private key as the `COMMON_SKILLS_SYNC_APP_PRIVATE_KEY` Actions secret in `common-skills`.
 ## Remove script
 `remove_common_skills` removes common agent skills listed in `skills-lock.json`.
 The script supports:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -105,7 +105,7 @@ Consumers invoke it through the same resolver as common skills:
 ```sh
 ./script/resolve_common_skills install_warp_skills -- --repo-root "${REPO_ROOT}" --if-needed
 ```
-Because `--best-effort` installs a distinct skill set, it honors the explicit target and skips the project-vs-global exclusivity checks scoped to the common-skills set, so warp-skills can coexist with a global common-skills install even when a skill name (for example `brandalf`) appears in both locks.
+`--best-effort` installs a distinct skill set into an explicit target, so it does not apply the project-vs-global exclusivity check (a guard that keeps a *single* set from being installed in both places). This lets warp-skills install to the project while common skills live globally. warp-skills should avoid reusing common-skill names; the bypass ensures an incidental name collision does not block the install.
 ## Update lock script
 `update_common_skills_lock` non-interactively regenerates an existing skills lockfile from the default branch of a skills source repo without installing skills into the target repository. By default it regenerates `skills-lock.json` from `warpdotdev/common-skills`; pass `--source <owner/repo>` and `--lock-file <name>` to regenerate another lock (e.g. `--source warpdotdev/warp-skills --lock-file warp-skills-lock.json`).
 It generates a candidate in a temporary Git repository, then copies back only a changed `skills-lock.json`. Generator failures and missing candidate output fail the command instead of retaining the existing lock.
@@ -119,7 +119,7 @@ The downstream lockfile update workflow uses this command before opening lockfil
 ## Downstream lockfile workflow
 `.github/workflows/update-downstream-skill-locks.yml` runs after every push to `main`. A single parametrized matrixed job refreshes both `skills-lock.json` (from `warpdotdev/common-skills`) and `warp-skills-lock.json` (from `warpdotdev/warp-skills`) in `warpdotdev/warp` and `warpdotdev/warp-server`, opening a lockfile-only pull request for each lock that changes.
 Each pull request requests the author of the originating common-skills pull request when possible and enables squash auto-merge. Direct pushes and authors who cannot review a target repository do not prevent pull request creation.
-The workflow requires a dedicated GitHub App installed on both downstream repositories with contents and pull-request write access. Configure its App ID as the `SKILLS_SYNC_APP_ID` Actions variable and its private key as the `SKILLS_SYNC_APP_PRIVATE_KEY` Actions secret in `common-skills`. (Renamed from `COMMON_SKILLS_SYNC_APP_ID`/`COMMON_SKILLS_SYNC_APP_PRIVATE_KEY` since the workflow now syncs both common-skills and warp-skills locks.)
+The workflow requires a dedicated GitHub App installed on both downstream repositories with contents and pull-request write access. Configure its App ID as the `SKILLS_SYNC_APP_ID` Actions variable and its private key as the `SKILLS_SYNC_APP_PRIVATE_KEY` Actions secret in `common-skills`.
 ## Remove script
 `remove_common_skills` removes common agent skills listed in `skills-lock.json`.
 The script supports:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,9 +2,11 @@
 These scripts help consuming repositories install, remove, and verify shared agent skills from `warpdotdev/common-skills`.
 ## Files
 - `resolve_common_skills`: resolves and executes scripts from this directory, a local override directory, or raw GitHub.
-- `install_common_skills`: installs or updates common skills, then verifies the installed contents.
+- `install_common_skills`: installs or updates skills from a lockfile, then verifies the installed contents. Parametrized by `--source`/`--lock-file`/`--label` so it can drive any skill set.
+- `install_warp_skills`: thin best-effort wrapper over `install_common_skills` for the internal `warpdotdev/warp-skills` set (`warp-skills-lock.json`).
 - `update_common_skills_lock`: regenerates an existing skills lockfile without installing skills; accepts `--source`/`--lock-file` to target any skills source (e.g. `warp-skills-lock.json` from `warpdotdev/warp-skills`).
-- `remove_common_skills`: removes installed common skills from a selected target.
+- `remove_common_skills`: removes installed skills listed in a lockfile from a selected target (`--lock-file`/`--label`).
+- `remove_warp_skills`: thin wrapper over `remove_common_skills` for the warp-skills set.
 ## Quick start
 Install common skills into the current checkout:
 ```sh
@@ -89,9 +91,21 @@ The script supports:
 - `--force`: install even if already up to date.
 - `--quiet`: suppress no-op output.
 - `--verify-only`: verify installed skills match `skills-lock.json` without installing.
+- `--source <owner/repo>`: skills source repository (default: `warpdotdev/common-skills`).
+- `--lock-file <name>`: lockfile name within the repo (default: `skills-lock.json`).
+- `--label <name>`: label used for the stamp file and messages (default: `common`).
+- `--best-effort`: on any failure or a missing lockfile, print a short notice and exit 0 (used for the optional internal warp-skills set).
 Successful install and skip paths verify that exactly one install target contains the locked common skills and that each installed skill matches `skills-lock.json`.
 Project installs add local Git exclude entries for only the locked common-skill directories so unrelated project skills in `.agents/skills` remain visible to Git.
 Global installs are shared across client repositories. A second repo pinned to the same lock verifies and succeeds without unnecessarily reinstalling; a repo pinned to a different lock fails with a version-mismatch error instead of overwriting the shared global install.
+## Internal warp-skills
+`install_warp_skills` and `remove_warp_skills` are thin wrappers that run `install_common_skills`/`remove_common_skills` against the internal `warpdotdev/warp-skills` set pinned in the consumer's `warp-skills-lock.json`. The install wrapper passes `--source warpdotdev/warp-skills --lock-file warp-skills-lock.json --label warp --best-effort` and installs into the same target as common skills (project unless `WARP_COMMON_SKILLS_INSTALL_TARGET=global`).
+This step is optional and never required for external contributors: it is best-effort, so a missing `warp-skills-lock.json` or no access to `warpdotdev/warp-skills` results in a short notice and exit 0 without failing the caller. Skip it with `--skip-warp-skills` or `WARP_SKIP_WARP_SKILLS_INSTALL=1`.
+Consumers invoke it through the same resolver as common skills:
+```sh
+./script/resolve_common_skills install_warp_skills -- --repo-root "${REPO_ROOT}" --if-needed
+```
+Because `--best-effort` installs a distinct skill set, it honors the explicit target and skips the project-vs-global exclusivity checks scoped to the common-skills set, so warp-skills can coexist with a global common-skills install even when a skill name (for example `brandalf`) appears in both locks.
 ## Update lock script
 `update_common_skills_lock` non-interactively regenerates an existing skills lockfile from the default branch of a skills source repo without installing skills into the target repository. By default it regenerates `skills-lock.json` from `warpdotdev/common-skills`; pass `--source <owner/repo>` and `--lock-file <name>` to regenerate another lock (e.g. `--source warpdotdev/warp-skills --lock-file warp-skills-lock.json`).
 It generates a candidate in a temporary Git repository, then copies back only a changed `skills-lock.json`. Generator failures and missing candidate output fail the command instead of retaining the existing lock.
@@ -128,7 +142,7 @@ Verification fails if:
 - `WARP_COMMON_SKILLS_TARGET_REPO_ROOT=/path/to/repo`: repository containing `skills-lock.json` and project-local `.agents/skills`.
 - `WARP_COMMON_SKILLS_REF=<git-ref>`: use a specific `warpdotdev/common-skills` branch, tag, or commit when creating a missing lock or checking interactively for lock updates.
 ## Lock hash stamps
-After a successful install, `install_common_skills` writes a stamp with the current `skills-lock.json` hash.
-- Project installs use git path `warp/common-skills-lock.hash`, or `.agents/skills/.common-skills-lock.hash` when git metadata is unavailable.
-- Global installs use `~/.agents/warp/common-skills-lock.hash`.
+After a successful install, `install_common_skills` writes a stamp with the current lockfile hash. The stamp filename is derived from `--label` (default `common`) so different skill sets do not collide (for example, `warp` uses `warp-skills-lock.hash`).
+- Project installs use git path `warp/<label>-skills-lock.hash`, or `.agents/skills/.<label>-skills-lock.hash` when git metadata is unavailable.
+- Global installs use `~/.agents/warp/<label>-skills-lock.hash`.
 The stamp lets `--if-needed` avoid reinstalling when the lock file and installed skills are already current.

--- a/scripts/install_common_skills
+++ b/scripts/install_common_skills
@@ -4,7 +4,12 @@ set -eo pipefail
 
 REPO_ROOT="${WARP_COMMON_SKILLS_TARGET_REPO_ROOT:-$(pwd)}"
 LOCK_FILE=""
-STAMP_RELATIVE_PATH="warp/common-skills-lock.hash"
+LOCK_FILE_NAME="skills-lock.json"
+LABEL="common"
+LABEL_TITLE="Common"
+BEST_EFFORT=0
+STAMP_BASENAME="common-skills-lock.hash"
+STAMP_RELATIVE_PATH="warp/${STAMP_BASENAME}"
 SKILLS_CLI_VERSION="1.5.6"
 COMMON_SKILLS_SOURCE="warpdotdev/common-skills"
 COMMON_SKILLS_REF="${WARP_COMMON_SKILLS_REF:-}"
@@ -22,10 +27,6 @@ TARGET="${WARP_COMMON_SKILLS_INSTALL_TARGET:-}"
 RESOLVED_TARGET=""
 ALLOW_GLOBAL_LOCK_UPDATE=0
 UPDATED_LOCK_CANDIDATE=""
-
-if [[ -n "${COMMON_SKILLS_REF}" ]]; then
-  COMMON_SKILLS_REQUEST_SOURCE="${COMMON_SKILLS_SOURCE}#${COMMON_SKILLS_REF}"
-fi
 
 resolve_repo_root() {
   cd "$1" && pwd
@@ -50,7 +51,7 @@ project_stamp_file() {
     return
   fi
 
-  echo "${REPO_ROOT}/.agents/skills/.common-skills-lock.hash"
+  echo "${REPO_ROOT}/.agents/skills/.${STAMP_BASENAME}"
 }
 
 project_exclude_file() {
@@ -72,7 +73,7 @@ project_exclude_file() {
 }
 
 global_stamp_file() {
-  echo "${HOME}/.agents/warp/common-skills-lock.hash"
+  echo "${HOME}/.agents/warp/${STAMP_BASENAME}"
 }
 
 stamp_file() {
@@ -191,6 +192,10 @@ Options:
   --force              Install even if the local stamp is already up to date.
   --quiet              Suppress "already up to date" informational output.
   --verify-only        Verify common skills without installing or updating them.
+  --source <owner/repo>  Skills source repository (default: warpdotdev/common-skills).
+  --lock-file <name>   Lockfile name within the repo (default: skills-lock.json).
+  --label <name>       Label used for stamp and messages (default: common).
+  --best-effort        On any failure or missing lock, print a notice and exit 0.
   -h, --help           Show this help message.
 
 Environment:
@@ -497,13 +502,25 @@ install_project_from_source() {
 }
 
 install_project_from_lock() {
-  (
-    cd "${REPO_ROOT}"
-    npx --yes "skills@${SKILLS_CLI_VERSION}" experimental_install
-  ) < /dev/null
+  # The skills CLI reads a file literally named skills-lock.json in its working
+  # directory. The default project lock already has that name, so install in
+  # place; any other lock (e.g. warp-skills-lock.json) installs via a temp dir.
+  if [[ "${LOCK_FILE_NAME}" = "skills-lock.json" ]]; then
+    (
+      cd "${REPO_ROOT}"
+      npx --yes "skills@${SKILLS_CLI_VERSION}" experimental_install
+    ) < /dev/null
+  else
+    install_lock_into_dir "${REPO_ROOT}/.agents/skills"
+  fi
 }
 
 install_global_from_lock() {
+  install_lock_into_dir "${HOME}/.agents/skills"
+}
+
+install_lock_into_dir() {
+  local target_skills_dir="$1"
   local skill_names=()
   local name=""
   local temp_dir=""
@@ -518,15 +535,29 @@ install_global_from_lock() {
     exit 1
   fi
 
-  temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/common-skills-global-install.XXXXXX")"
+  temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/skills-lock-install.XXXXXX")"
   cp "${LOCK_FILE}" "${temp_dir}/skills-lock.json"
 
-  (
+  if ! (
     cd "${temp_dir}"
+    # Best-effort installs must not block on a credential prompt when the source
+    # repo is inaccessible (e.g. external contributors without warp access);
+    # fail fast and let the caller skip instead.
+    if [[ "${BEST_EFFORT}" -eq 1 ]]; then
+      export GIT_TERMINAL_PROMPT=0
+    fi
     npx --yes "skills@${SKILLS_CLI_VERSION}" experimental_install
-  ) < /dev/null
+  ) < /dev/null; then
+    rm -rf "${temp_dir}"
+    if [[ "${BEST_EFFORT}" -eq 1 ]]; then
+      echo "${LABEL}-skills not installed (no access) — skipping."
+      exit 0
+    fi
+    echo "error: failed to install skills from ${LOCK_FILE}" >&2
+    exit 1
+  fi
 
-  mkdir -p "${HOME}/.agents/skills"
+  mkdir -p "${target_skills_dir}"
   for name in "${skill_names[@]}"; do
     skill_dir="${temp_dir}/.agents/skills/${name}"
     if [[ ! -d "${skill_dir}" ]]; then
@@ -535,8 +566,8 @@ install_global_from_lock() {
       exit 1
     fi
 
-    rm -rf -- "${HOME}/.agents/skills/${name}"
-    cp -R "${skill_dir}" "${HOME}/.agents/skills/${name}"
+    rm -rf -- "${target_skills_dir}/${name}"
+    cp -R "${skill_dir}" "${target_skills_dir}/${name}"
   done
 
   rm -rf "${temp_dir}"
@@ -578,8 +609,8 @@ ensure_project_common_skills_ignored() {
   local path=""
   local skill_dir=""
   local tmp_file=""
-  local marker_start="# BEGIN warp common-skills"
-  local marker_end="# END warp common-skills"
+  local marker_start="# BEGIN warp ${LABEL}-skills"
+  local marker_end="# END warp ${LABEL}-skills"
 
   if [[ "${TARGET}" != "project" ]]; then
     return 0
@@ -669,7 +700,7 @@ verify_common_skills() {
     exit 1
   fi
 
-  node - "${LOCK_FILE}" "${REPO_ROOT}" "${HOME}" "${TARGET}" "${QUIET}" "$(global_stamp_file)" <<'NODE'
+  node - "${LOCK_FILE}" "${REPO_ROOT}" "${HOME}" "${TARGET}" "${QUIET}" "$(global_stamp_file)" "${LABEL_TITLE}" "${LOCK_FILE_NAME}" "${BEST_EFFORT}" <<'NODE'
 const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
@@ -680,6 +711,12 @@ const home = process.argv[4];
 let target = process.argv[5];
 const quiet = process.argv[6] === "1";
 const globalStampFile = process.argv[7];
+const labelTitle = process.argv[8];
+const lockFileName = process.argv[9];
+// When best-effort (e.g. the warp-skills set), skip cross-target dedupe so a
+// same-named skill installed by another set (e.g. common-skills) does not trip
+// the project-vs-global exclusivity checks.
+const strict = process.argv[10] !== "1";
 
 function fail(messages) {
   for (const message of messages) {
@@ -791,7 +828,7 @@ function verifyTarget(skills, installTarget) {
     const normalizedComputedHash =
       computedHash === skill.computedHash ? computedHash : computeSkillFolderHash(skillDir, true);
     if (normalizedComputedHash !== skill.computedHash) {
-      errors.push(`error: ${name} does not match skills-lock.json`);
+      errors.push(`error: ${name} does not match ${lockFileName}`);
       errors.push(`  expected: ${skill.computedHash}`);
       errors.push(`  actual:   ${computedHash}`);
     }
@@ -806,14 +843,14 @@ const skills = lockedSkills();
 const projectPresent = containsLockedSkill(skills, "project");
 const globalPresent = fs.existsSync(globalStampFile) || containsLockedSkill(skills, "global");
 
-if (projectPresent && globalPresent) {
+if (strict && projectPresent && globalPresent) {
   fail([
     "error: common agent skills are installed in both this checkout's .agents/skills and ~/.agents/skills.",
     `Remove one copy with scripts/remove_common_skills --repo-root ${repoRoot} or scripts/remove_common_skills --repo-root ${repoRoot} --global, then rerun.`,
   ]);
 }
 
-if (!projectPresent && !globalPresent) {
+if (strict && !projectPresent && !globalPresent) {
   fail([
     "error: common agent skills are not installed in this checkout's .agents/skills or ~/.agents/skills.",
     `Install them with scripts/install_common_skills --repo-root ${repoRoot}, then rerun.`,
@@ -838,7 +875,7 @@ if (target) {
 
 verifyTarget(skills, target);
 if (!quiet) {
-  console.log(`Common skills are installed in ${target === "global" ? "~/.agents/skills" : ".agents/skills"} and match skills-lock.json.`);
+  console.log(`${labelTitle} skills are installed in ${target === "global" ? "~/.agents/skills" : ".agents/skills"} and match ${lockFileName}.`);
 }
 NODE
 }
@@ -887,6 +924,40 @@ while [[ $# -gt 0 ]]; do
       VERIFY_ONLY=1
       shift
       ;;
+    --source)
+      if [[ -n "${2:-}" ]]; then
+        COMMON_SKILLS_SOURCE="$2"
+        shift 2
+      else
+        echo "error: argument for $1 is missing" >&2
+        usage >&2
+        exit 1
+      fi
+      ;;
+    --lock-file)
+      if [[ -n "${2:-}" ]]; then
+        LOCK_FILE_NAME="$2"
+        shift 2
+      else
+        echo "error: argument for $1 is missing" >&2
+        usage >&2
+        exit 1
+      fi
+      ;;
+    --label)
+      if [[ -n "${2:-}" ]]; then
+        LABEL="$2"
+        shift 2
+      else
+        echo "error: argument for $1 is missing" >&2
+        usage >&2
+        exit 1
+      fi
+      ;;
+    --best-effort)
+      BEST_EFFORT=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -903,7 +974,14 @@ if ! REPO_ROOT="$(resolve_repo_root "${REPO_ROOT}")"; then
   echo "error: repo root does not exist: ${REPO_ROOT}" >&2
   exit 1
 fi
-LOCK_FILE="${REPO_ROOT}/skills-lock.json"
+LOCK_FILE="${REPO_ROOT}/${LOCK_FILE_NAME}"
+STAMP_BASENAME="${LABEL}-skills-lock.hash"
+STAMP_RELATIVE_PATH="warp/${STAMP_BASENAME}"
+LABEL_TITLE="$(printf '%s' "${LABEL:0:1}" | tr '[:lower:]' '[:upper:]')${LABEL:1}"
+COMMON_SKILLS_REQUEST_SOURCE="${COMMON_SKILLS_SOURCE}"
+if [[ -n "${COMMON_SKILLS_REF}" ]]; then
+  COMMON_SKILLS_REQUEST_SOURCE="${COMMON_SKILLS_SOURCE}#${COMMON_SKILLS_REF}"
+fi
 if [[ "${WARP_SKIP_COMMON_SKILLS_INSTALL:-}" = "1" ]]; then
   log "Skipping common-skills install because WARP_SKIP_COMMON_SKILLS_INSTALL=1."
   exit 0
@@ -926,21 +1004,44 @@ if [[ "${VERIFY_ONLY}" -eq 1 ]]; then
   verify_common_skills
   exit 0
 fi
+if [[ "${BEST_EFFORT}" -eq 1 ]]; then
+  for required_tool in git node npm npx; do
+    if ! command -v "${required_tool}" >/dev/null 2>&1; then
+      log "${LABEL}-skills not installed (required tooling '${required_tool}' unavailable) — skipping."
+      exit 0
+    fi
+  done
+fi
 validate_install_dependencies
-maybe_prompt_for_upstream_lock_update
+if [[ "${BEST_EFFORT}" -ne 1 ]]; then
+  maybe_prompt_for_upstream_lock_update
+fi
 if [[ "${FORCE}" -ne 1 && "${IF_NEEDED}" -eq 1 && -z "${TARGET}" ]] && common_skills_already_up_to_date_without_target; then
-  log "Common skills are already up to date."
+  log "${LABEL_TITLE} skills are already up to date."
   exit 0
 fi
-fail_if_target_requires_unavailable_prompt
-if ! RESOLVED_TARGET="$(resolve_common_skills_target)"; then
-  echo "error: could not resolve common skills install target" >&2
-  usage >&2
-  exit 1
+if [[ "${BEST_EFFORT}" -eq 1 && -n "${TARGET}" ]]; then
+  # Best-effort installs (e.g. warp-skills) honor the explicit target and skip
+  # the cross-target dedupe, which is scoped to a single skill set.
+  if ! RESOLVED_TARGET="$(normalize_common_skills_target "${TARGET}")"; then
+    echo "error: invalid install target: ${TARGET} (expected project or global)" >&2
+    exit 1
+  fi
+else
+  fail_if_target_requires_unavailable_prompt
+  if ! RESOLVED_TARGET="$(resolve_common_skills_target)"; then
+    echo "error: could not resolve common skills install target" >&2
+    usage >&2
+    exit 1
+  fi
 fi
 TARGET="${RESOLVED_TARGET}"
 if [[ ! -f "${LOCK_FILE}" ]]; then
-  echo "Creating skills-lock.json from ${COMMON_SKILLS_REQUEST_SOURCE}."
+  if [[ "${BEST_EFFORT}" -eq 1 ]]; then
+    log "${LABEL}-skills not installed (no ${LOCK_FILE_NAME} present) — skipping."
+    exit 0
+  fi
+  echo "Creating ${LOCK_FILE_NAME} from ${COMMON_SKILLS_REQUEST_SOURCE}."
   install_project_from_source
   if [[ ! -f "${LOCK_FILE}" ]]; then
     echo "error: expected ${LOCK_FILE} to be created by skills add" >&2
@@ -970,12 +1071,12 @@ fail_if_global_lock_mismatch
 ensure_project_common_skills_ignored
 
 if [[ "${FORCE}" -ne 1 && "${IF_NEEDED}" -eq 1 && "${STAMP_HASH}" = "${LOCK_HASH}" ]] && locked_skills_installed; then
-  log "Common skills are already up to date."
+  log "${LABEL_TITLE} skills are already up to date."
   verify_common_skills
   exit 0
 fi
 
-echo "Installing common agent skills from skills-lock.json into $(target_description)."
+echo "Installing ${LABEL} agent skills from ${LOCK_FILE_NAME} into $(target_description)."
 install_from_lock
 LOCK_HASH="$(lock_hash)"
 mkdir -p "$(dirname "${STAMP_FILE}")"

--- a/scripts/install_common_skills
+++ b/scripts/install_common_skills
@@ -713,9 +713,9 @@ const quiet = process.argv[6] === "1";
 const globalStampFile = process.argv[7];
 const labelTitle = process.argv[8];
 const lockFileName = process.argv[9];
-// When best-effort (e.g. the warp-skills set), skip cross-target dedupe so a
-// same-named skill installed by another set (e.g. common-skills) does not trip
-// the project-vs-global exclusivity checks.
+// Best-effort sets install a distinct lock into an explicit target, so skip the
+// within-set project-vs-global exclusivity check; an incidental name collision
+// across sets must not block the install.
 const strict = process.argv[10] !== "1";
 
 function fail(messages) {

--- a/scripts/install_common_skills
+++ b/scripts/install_common_skills
@@ -195,7 +195,7 @@ Options:
   --source <owner/repo>  Skills source repository (default: warpdotdev/common-skills).
   --lock-file <name>   Lockfile name within the repo (default: skills-lock.json).
   --label <name>       Label used for stamp and messages (default: common).
-  --best-effort        On any failure or missing lock, print a notice and exit 0.
+  --best-effort        On any failure or missing lock, print a notice and exit 0 (keeps an optional set like warp-skills from blocking the caller).
   -h, --help           Show this help message.
 
 Environment:
@@ -549,6 +549,8 @@ install_lock_into_dir() {
     npx --yes "skills@${SKILLS_CLI_VERSION}" experimental_install
   ) < /dev/null; then
     rm -rf "${temp_dir}"
+    # Best-effort: a failed install (e.g. no repo access) is non-fatal — emit a
+    # notice and exit 0 so the caller (bootstrap/run) continues.
     if [[ "${BEST_EFFORT}" -eq 1 ]]; then
       echo "${LABEL}-skills not installed (no access) — skipping."
       exit 0
@@ -700,7 +702,7 @@ verify_common_skills() {
     exit 1
   fi
 
-  node - "${LOCK_FILE}" "${REPO_ROOT}" "${HOME}" "${TARGET}" "${QUIET}" "$(global_stamp_file)" "${LABEL_TITLE}" "${LOCK_FILE_NAME}" "${BEST_EFFORT}" <<'NODE'
+  node - "${LOCK_FILE}" "${REPO_ROOT}" "${HOME}" "${TARGET}" "${QUIET}" "$(global_stamp_file)" "${LABEL_TITLE}" "${LOCK_FILE_NAME}" <<'NODE'
 const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
@@ -713,10 +715,6 @@ const quiet = process.argv[6] === "1";
 const globalStampFile = process.argv[7];
 const labelTitle = process.argv[8];
 const lockFileName = process.argv[9];
-// Best-effort sets install a distinct lock into an explicit target, so skip the
-// within-set project-vs-global exclusivity check; an incidental name collision
-// across sets must not block the install.
-const strict = process.argv[10] !== "1";
 
 function fail(messages) {
   for (const message of messages) {
@@ -843,14 +841,14 @@ const skills = lockedSkills();
 const projectPresent = containsLockedSkill(skills, "project");
 const globalPresent = fs.existsSync(globalStampFile) || containsLockedSkill(skills, "global");
 
-if (strict && projectPresent && globalPresent) {
+if (projectPresent && globalPresent) {
   fail([
     "error: common agent skills are installed in both this checkout's .agents/skills and ~/.agents/skills.",
     `Remove one copy with scripts/remove_common_skills --repo-root ${repoRoot} or scripts/remove_common_skills --repo-root ${repoRoot} --global, then rerun.`,
   ]);
 }
 
-if (strict && !projectPresent && !globalPresent) {
+if (!projectPresent && !globalPresent) {
   fail([
     "error: common agent skills are not installed in this checkout's .agents/skills or ~/.agents/skills.",
     `Install them with scripts/install_common_skills --repo-root ${repoRoot}, then rerun.`,
@@ -1020,23 +1018,17 @@ if [[ "${FORCE}" -ne 1 && "${IF_NEEDED}" -eq 1 && -z "${TARGET}" ]] && common_sk
   log "${LABEL_TITLE} skills are already up to date."
   exit 0
 fi
-if [[ "${BEST_EFFORT}" -eq 1 && -n "${TARGET}" ]]; then
-  # Best-effort installs (e.g. warp-skills) honor the explicit target and skip
-  # the cross-target dedupe, which is scoped to a single skill set.
-  if ! RESOLVED_TARGET="$(normalize_common_skills_target "${TARGET}")"; then
-    echo "error: invalid install target: ${TARGET} (expected project or global)" >&2
-    exit 1
-  fi
-else
-  fail_if_target_requires_unavailable_prompt
-  if ! RESOLVED_TARGET="$(resolve_common_skills_target)"; then
-    echo "error: could not resolve common skills install target" >&2
-    usage >&2
-    exit 1
-  fi
+fail_if_target_requires_unavailable_prompt
+if ! RESOLVED_TARGET="$(resolve_common_skills_target)"; then
+  echo "error: could not resolve common skills install target" >&2
+  usage >&2
+  exit 1
 fi
 TARGET="${RESOLVED_TARGET}"
 if [[ ! -f "${LOCK_FILE}" ]]; then
+  # A committed lock is how a consumer opts into a set. For best-effort sets
+  # (warp-skills), a missing lock means "not adopted", so skip rather than
+  # create one — creating needs source access and would add an unreviewed lock.
   if [[ "${BEST_EFFORT}" -eq 1 ]]; then
     log "${LABEL}-skills not installed (no ${LOCK_FILE_NAME} present) — skipping."
     exit 0

--- a/scripts/install_warp_skills
+++ b/scripts/install_warp_skills
@@ -31,14 +31,6 @@ case "${target}" in
   *) target="project" ;;
 esac
 
-# --skip-warp-skills is handled above; drop it before forwarding.
-forwarded=()
-for arg in "$@"; do
-  case "${arg}" in
-    --skip-warp-skills) ;;
-    *) forwarded+=("${arg}") ;;
-  esac
-done
 
 exec "${SCRIPT_DIR}/install_common_skills" \
   --source warpdotdev/warp-skills \
@@ -46,4 +38,4 @@ exec "${SCRIPT_DIR}/install_common_skills" \
   --label warp \
   --best-effort \
   "--${target}" \
-  "${forwarded[@]}"
+  "$@"

--- a/scripts/install_warp_skills
+++ b/scripts/install_warp_skills
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Best-effort installer for the internal warpdotdev/warp-skills skills pinned in
+# warp-skills-lock.json. Thin wrapper over install_common_skills; optional and
+# never required for external contributors (it skips cleanly without access).
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+for arg in "$@"; do
+  case "${arg}" in
+    --skip-warp-skills)
+      echo "warp-skills install skipped (--skip-warp-skills)."
+      exit 0
+      ;;
+  esac
+done
+
+if [[ "${WARP_SKIP_WARP_SKILLS_INSTALL:-}" = "1" ]]; then
+  echo "warp-skills install skipped (WARP_SKIP_WARP_SKILLS_INSTALL=1)."
+  exit 0
+fi
+
+# Match the common-skills target rule: project unless the shared target env is
+# global. An explicit --project/--global in "$@" still wins, since
+# install_common_skills honors the last target flag it sees.
+target="${WARP_COMMON_SKILLS_INSTALL_TARGET:-project}"
+case "${target}" in
+  project|global) ;;
+  *) target="project" ;;
+esac
+
+# --skip-warp-skills is handled above; drop it before forwarding.
+forwarded=()
+for arg in "$@"; do
+  case "${arg}" in
+    --skip-warp-skills) ;;
+    *) forwarded+=("${arg}") ;;
+  esac
+done
+
+exec "${SCRIPT_DIR}/install_common_skills" \
+  --source warpdotdev/warp-skills \
+  --lock-file warp-skills-lock.json \
+  --label warp \
+  --best-effort \
+  "--${target}" \
+  "${forwarded[@]}"

--- a/scripts/remove_common_skills
+++ b/scripts/remove_common_skills
@@ -4,7 +4,10 @@ set -eo pipefail
 
 REPO_ROOT="${WARP_COMMON_SKILLS_TARGET_REPO_ROOT:-$(pwd)}"
 LOCK_FILE=""
-STAMP_RELATIVE_PATH="warp/common-skills-lock.hash"
+LOCK_FILE_NAME="skills-lock.json"
+LABEL="common"
+STAMP_BASENAME="common-skills-lock.hash"
+STAMP_RELATIVE_PATH="warp/${STAMP_BASENAME}"
 CLEAR_LOCK=0
 
 TARGET="${WARP_COMMON_SKILLS_INSTALL_TARGET:-project}"
@@ -28,7 +31,7 @@ project_stamp_file() {
     return
   fi
 
-  echo "${REPO_ROOT}/.agents/skills/.common-skills-lock.hash"
+  echo "${REPO_ROOT}/.agents/skills/.${STAMP_BASENAME}"
 }
 
 project_exclude_file() {
@@ -50,7 +53,7 @@ project_exclude_file() {
 }
 
 global_stamp_file() {
-  echo "${HOME}/.agents/warp/common-skills-lock.hash"
+  echo "${HOME}/.agents/warp/${STAMP_BASENAME}"
 }
 
 stamp_file() {
@@ -134,6 +137,8 @@ Options:
   --project            Remove from this checkout's .agents/skills directory (default).
   --global             Remove from ~/.agents/skills for the current user.
   --clear-lock         Also remove skills-lock.json after removing locked skills.
+  --lock-file <name>   Lockfile name within the repo (default: skills-lock.json).
+  --label <name>       Label used for the stamp and ignore markers (default: common).
   -h, --help           Show this help message.
 
 Environment:
@@ -210,8 +215,8 @@ remove_from_lock() {
 remove_project_common_skills_ignore_block() {
   local exclude_file=""
   local tmp_file=""
-  local marker_start="# BEGIN warp common-skills"
-  local marker_end="# END warp common-skills"
+  local marker_start="# BEGIN warp ${LABEL}-skills"
+  local marker_end="# END warp ${LABEL}-skills"
 
   if ! exclude_file="$(project_exclude_file)"; then
     return 0
@@ -255,6 +260,26 @@ while [[ $# -gt 0 ]]; do
       CLEAR_LOCK=1
       shift
       ;;
+    --lock-file)
+      if [[ -n "${2:-}" ]]; then
+        LOCK_FILE_NAME="$2"
+        shift 2
+      else
+        echo "error: argument for $1 is missing" >&2
+        usage >&2
+        exit 1
+      fi
+      ;;
+    --label)
+      if [[ -n "${2:-}" ]]; then
+        LABEL="$2"
+        shift 2
+      else
+        echo "error: argument for $1 is missing" >&2
+        usage >&2
+        exit 1
+      fi
+      ;;
     -h|--help)
       usage
       exit 0
@@ -271,7 +296,9 @@ if ! REPO_ROOT="$(resolve_repo_root "${REPO_ROOT}")"; then
   echo "error: repo root does not exist: ${REPO_ROOT}" >&2
   exit 1
 fi
-LOCK_FILE="${REPO_ROOT}/skills-lock.json"
+LOCK_FILE="${REPO_ROOT}/${LOCK_FILE_NAME}"
+STAMP_BASENAME="${LABEL}-skills-lock.hash"
+STAMP_RELATIVE_PATH="warp/${STAMP_BASENAME}"
 
 if [[ "${TARGET}" != "project" && "${TARGET}" != "global" ]]; then
   echo "error: invalid common skills removal target: ${TARGET} (expected project or global)" >&2
@@ -289,7 +316,7 @@ if [[ ! -f "${LOCK_FILE}" ]]; then
 fi
 validate_required_commands git node
 
-echo "Removing common agent skills listed in skills-lock.json from $(target_description)."
+echo "Removing ${LABEL} agent skills listed in ${LOCK_FILE_NAME} from $(target_description)."
 remove_from_lock
 if [[ "${CLEAR_LOCK}" -eq 1 ]]; then
   rm -f -- "${LOCK_FILE}"

--- a/scripts/remove_warp_skills
+++ b/scripts/remove_warp_skills
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Remove the internal warpdotdev/warp-skills skills listed in
+# warp-skills-lock.json. Thin wrapper over remove_common_skills.
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec "${SCRIPT_DIR}/remove_common_skills" \
+  --lock-file warp-skills-lock.json \
+  --label warp \
+  "$@"

--- a/scripts/update_common_skills_lock
+++ b/scripts/update_common_skills_lock
@@ -4,21 +4,24 @@ set -eo pipefail
 
 REPO_ROOT="$(pwd)"
 LOCK_FILE=""
+LOCK_FILE_NAME="skills-lock.json"
 TEMP_DIR=""
 SKILLS_CLI_VERSION="1.5.6"
-COMMON_SKILLS_SOURCE="warpdotdev/common-skills"
+SKILLS_SOURCE="warpdotdev/common-skills"
 SKILLS_CLI_AGENT="warp"
-COMMON_SKILL_SELECTOR="*"
+SKILL_SELECTOR="*"
 
 usage() {
   cat <<EOF
 Usage: scripts/update_common_skills_lock [options]
 
-Regenerate an existing skills-lock.json from warpdotdev/common-skills.
+Regenerate an existing skills lockfile from a skills source repository.
 
 Options:
-  --repo-root <path>   Repository containing skills-lock.json.
-  -h, --help           Show this help message.
+  --repo-root <path>      Repository containing the lockfile (default: current directory).
+  --source <owner/repo>   Skills source to regenerate from (default: warpdotdev/common-skills).
+  --lock-file <name>      Lockfile name within the repo (default: skills-lock.json).
+  -h, --help              Show this help message.
 EOF
 }
 
@@ -55,6 +58,24 @@ while [[ $# -gt 0 ]]; do
       REPO_ROOT="$2"
       shift 2
       ;;
+    --source)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --source requires an owner/repo." >&2
+        usage >&2
+        exit 1
+      fi
+      SKILLS_SOURCE="$2"
+      shift 2
+      ;;
+    --lock-file)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --lock-file requires a filename." >&2
+        usage >&2
+        exit 1
+      fi
+      LOCK_FILE_NAME="$2"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -74,32 +95,34 @@ if ! REPO_ROOT="$(cd "${REPO_ROOT}" && pwd)"; then
   exit 1
 fi
 
-LOCK_FILE="${REPO_ROOT}/skills-lock.json"
+LOCK_FILE="${REPO_ROOT}/${LOCK_FILE_NAME}"
 if [[ ! -f "${LOCK_FILE}" ]]; then
   echo "error: missing skills lock file: ${LOCK_FILE}" >&2
   exit 1
 fi
 
 trap cleanup EXIT
-TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/common-skills-lock.XXXXXX")"
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/skills-lock.XXXXXX")"
+# The skills CLI reads and writes a file literally named skills-lock.json in its
+# working directory, so seed the temp dir with the consumer's lock under that name.
 cp "${LOCK_FILE}" "${TEMP_DIR}/skills-lock.json"
 git -C "${TEMP_DIR}" init --quiet
 
 if ! (
   cd "${TEMP_DIR}"
-  npx --yes "skills@${SKILLS_CLI_VERSION}" add "${COMMON_SKILLS_SOURCE}" -a "${SKILLS_CLI_AGENT}" -s "${COMMON_SKILL_SELECTOR}" -y --copy
+  npx --yes "skills@${SKILLS_CLI_VERSION}" add "${SKILLS_SOURCE}" -a "${SKILLS_CLI_AGENT}" -s "${SKILL_SELECTOR}" -y --copy
 ) < /dev/null; then
-  echo "error: failed to generate an updated skills-lock.json from ${COMMON_SKILLS_SOURCE}." >&2
+  echo "error: failed to generate an updated ${LOCK_FILE_NAME} from ${SKILLS_SOURCE}." >&2
   exit 1
 fi
 
 if [[ ! -f "${TEMP_DIR}/skills-lock.json" ]]; then
-  echo "error: common skills update did not produce a candidate skills-lock.json." >&2
+  echo "error: skills update did not produce a candidate lockfile from ${SKILLS_SOURCE}." >&2
   exit 1
 fi
 
 if cmp -s "${LOCK_FILE}" "${TEMP_DIR}/skills-lock.json"; then
-  echo "skills-lock.json is already up to date."
+  echo "${LOCK_FILE_NAME} is already up to date."
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

Extends the shared common-skills tooling so that the internal [warp-skills repo](https://github.com/warpdotdev/warp-skills) is installed and kept in sync the same way common skills are. 

This is part of a series of changes intended to make common-skills plug-and-play with any repo (which should be particularly helpful for enterprises we're working with, like Narwhal) and present a public-facing library of skills curated by Warp. The end-goal here is to make our common skills library akin to something like [this](https://github.com/mattpocock/skills), rather than a set of skills specific to our client/server. Here's some more context on the motivation behind this change: https://warpdev.slack.com/archives/C08KTPNQN65/p1781557027648009.

This PR lets `warp` and `warp-server` drop their vendored `install_warp_skills` copies and call a shared wrapper through the existing `resolve_common_skills` resolver. Related client and server PRs:

- https://github.com/warpdotdev/warp/pull/13247
- https://github.com/warpdotdev/warp-server/pull/12250

## Changes

### Installer

- `install_common_skills` gains `--source`, `--lock-file`, `--label`, and `--best-effort`, so one code path can drive any skill set. Defaults reproduce the current common-skills behavior exactly.
    - Non-default locks install through a temp dir (lock copied to `skills-lock.json`) before `experimental_install`, then skill dirs are copied into the target — the same approach the global path already uses.
    - `--best-effort` turns a missing lock or no repo access into a one-line notice + exit 0, sets `GIT_TERMINAL_PROMPT=0` so an inaccessible source fails fast without a credential prompt, and skips the interactive upstream-update check. It does **not** relax the naming guard below.
- The project-vs-global exclusivity check applies to **every** set, including warp-skills: a skill name found in both `.agents/skills` and `~/.agents/skills` fails the install rather than silently landing in two places. Since warp-skills and common skills use distinct names, this also surfaces any accidental naming collision between the two sets.
- `install_warp_skills` / `remove_warp_skills` are thin wrappers that call the parametrized scripts with the warp-skills source/lock/label and `--best-effort`; they honor `--skip-warp-skills` / `WARP_SKIP_WARP_SKILLS_INSTALL=1`.
- Stamp filenames are label-scoped (`common-skills-lock.hash`, `warp-skills-lock.hash`) so the two sets don't collide.

### Downstream lock automation

- `update_common_skills_lock` gains `--source`/`--lock-file`, and a single parametrized matrix job in `update-downstream-skill-locks.yml` refreshes both `skills-lock.json` and `warp-skills-lock.json` in `warp`/`warp-server`, opening a lockfile-only PR per changed lock. A consumer that doesn't yet carry a given lock is skipped rather than failing the job. The workflow keeps using the existing `COMMON_SKILLS_SYNC_APP_ID` variable and `COMMON_SKILLS_SYNC_APP_PRIVATE_KEY` secret — no repo-settings changes required.

## Testing

Exercised the shared scripts via the resolver chain (`WARP_COMMON_SKILLS_SCRIPTS_DIR` → this branch's `scripts/`) and the remote fetch path (`WARP_COMMON_SKILLS_REF`):

- **Backward-compat (common skills):** `install_common_skills` with defaults, in an isolated `HOME`, installs all 20 common skills, verifies (`… match skills-lock.json`), and writes `common-skills-lock.hash`. Project/global behavior is unchanged.
- **warp-skills install** via the wrapper (against a ref that carries the content) installs the locked skills, verifies (`… match warp-skills-lock.json`), writes `warp-skills-lock.hash`, and is idempotent under `--if-needed`.
- **Best-effort / opt-out:** `--skip-warp-skills`, `WARP_SKIP_WARP_SKILLS_INSTALL=1`, and a missing lock all exit 0 with a clean notice; an inaccessible source fails fast (no credential prompt) and skips.
- **Removal:** `remove_warp_skills` removes the locked skills and the stamp.

Note: the downstream `warp-skills-lock.json` currently pins `ref: main`, but the warp-skills content is not on `main` yet, so a real install no-ops there until the lock is regenerated against the finalized branch (see the client/server PRs).

## Follow-up

- Once warp-skills content lands on `main`, regenerate `warp-skills-lock.json` (`update_common_skills_lock --source warpdotdev/warp-skills --lock-file warp-skills-lock.json`); the wrapper is lock-driven and needs no change.

---

_Plan: https://staging.warp.dev/drive/notebook/R4ucMiSKpclPGJXzpoFu4t_

_This PR was generated with_ [_Oz](https://warp.dev/oz)._
