### PR TITLE
write-feature-docs + scan-new-specs: post-merge improvements

### DIFF
--- a/.agents/skills/scan-new-specs/SKILL.md
+++ b/.agents/skills/scan-new-specs/SKILL.md
@@ -12,8 +12,6 @@ Scan `warpdotdev/warp` and `warp-server` for recently merged product or tech spe
 
 In both cases, post a summary to `#growth-docs`.
 
-> **TODO for reviewers:** `#growth-docs` is a temporary channel for engineer pings. Identify a more appropriate eng-facing channel (e.g. a shared eng/docs channel, `#dev`, or a dedicated `#docs-requests` channel) once this workflow is established.
-
 ## Configuration
 
 Before running, confirm these values (or accept the defaults):
@@ -21,7 +19,7 @@ Before running, confirm these values (or accept the defaults):
 | Setting | Default | Description |
 |---|---|---|
 | `LOOKBACK_DAYS` | `3` | How many days back to scan for merged spec PRs |
-| `SLACK_CHANNEL` | `#growth-docs` | Slack channel for engineer pings and summaries (temporary — see TODO above) |
+| `SLACK_CHANNEL` | `#growth-docs` | Slack channel for engineer pings and summaries |
 | `SLACK_BOT_TOKEN` | From `buzz` environment | Slack bot token for posting via API (already available in the `buzz` Oz environment) |
 
 This skill uses the Slack API (`chat.postMessage`) rather than an incoming webhook, which enables real user pings. The `buzz` Oz environment already has the required `SLACK_BOT_TOKEN`. No new secrets setup is needed.

--- a/.agents/skills/scan-new-specs/SKILL.md
+++ b/.agents/skills/scan-new-specs/SKILL.md
@@ -130,7 +130,7 @@ For each uncovered spec, read `specs/<id>/PRODUCT.md` and assess whether it has 
 
 1. Run `write-feature-docs` in **ambient mode** (see `write-feature-docs` skill for details) — this skips the interactive outline confirmation and instead embeds the outline as a checklist in the PR description
 2. The PR is opened in `warpdotdev/docs` with the draft and a checklist of items needing engineer verification
-3. Request review from the engineer (`@<github-username>`) and from `@rachaelrenk`, `@petradonka`, and `@hongyi-chen`
+3. Request review from the engineer (`@<github-username>`) and from `@rachaelrenk` and `@hongyi-chen`
 4. Post this Slack message to `SLACK_CHANNEL`:
 
 ```

--- a/.agents/skills/write-feature-docs/SKILL.md
+++ b/.agents/skills/write-feature-docs/SKILL.md
@@ -344,17 +344,17 @@ After generating the draft, submit it to `warpdotdev/docs` automatically:
    { label: '<Feature name>', link: '/<section>/<feature-name>/' },
    ```
 4. Commit and push on a new branch named `docs/<spec-id>-feature-draft`
-5. **Write the PR body using the `create_file` tool**, then open a **draft PR** in `warpdotdev/docs` with `--body-file`. The PR description must include:
+5. **Write the PR body to a temp file, then open a draft PR with `--body-file`**. The PR description must include:
    - The feature name and spec ID
    - A link to the original spec PR
    - A list of all `[UNVERIFIED]` and `[TODO]` items in the draft for reviewer attention
 
-   Use `create_file` to write the body to `/tmp/pr-body.md`, then pass it to `gh`:
+   Write the body to `/tmp/pr-body.md` using whatever file-writing method is available (a file-creation tool, a Python `open()` call, or a shell `cat` with a quoted heredoc), then pass it to `gh`:
    ```bash
    gh pr create --draft --body-file /tmp/pr-body.md ...
    ```
 
-   **Never write the PR body via a shell command** (heredoc, `echo`, `printf`, or `--body "..."`). Shell tools process backticks, `[x]` glob patterns, and `$vars` inside the string before writing — corrupting markdown content. The `create_file` tool writes bytes directly to disk without any shell interpretation, making it the only safe method for PR bodies that contain markdown with backticks or `[ ]` / `[x]` checkbox syntax.
+   **Never pass the PR body inline** (via `--body "..."`, `echo`, or `printf` piped directly to `gh`). Shell string interpolation expands backticks, `$vars`, and `[ ]` glob patterns before the string reaches `gh`, corrupting any markdown that contains those characters. Writing to a file first avoids all shell interpretation of the content.
 
    **In the "Docs outline" section of the PR body, use plain bullet points** (`-`) for agent-verified items, not `- [x]` checkboxes. Reserve `- [ ]` checkboxes only for the "Items needing review" section so reviewers know exactly which items require their action.
 

--- a/.agents/skills/write-feature-docs/SKILL.md
+++ b/.agents/skills/write-feature-docs/SKILL.md
@@ -344,10 +344,20 @@ After generating the draft, submit it to `warpdotdev/docs` automatically:
    { label: '<Feature name>', link: '/<section>/<feature-name>/' },
    ```
 4. Commit and push on a new branch named `docs/<spec-id>-feature-draft`
-5. Open a **draft PR** in `warpdotdev/docs` with a description that includes:
+5. **Write the PR body using the `create_file` tool**, then open a **draft PR** in `warpdotdev/docs` with `--body-file`. The PR description must include:
    - The feature name and spec ID
    - A link to the original spec PR
    - A list of all `[UNVERIFIED]` and `[TODO]` items in the draft for reviewer attention
+
+   Use `create_file` to write the body to `/tmp/pr-body.md`, then pass it to `gh`:
+   ```bash
+   gh pr create --draft --body-file /tmp/pr-body.md ...
+   ```
+
+   **Never write the PR body via a shell command** (heredoc, `echo`, `printf`, or `--body "..."`). Shell tools process backticks, `[x]` glob patterns, and `$vars` inside the string before writing — corrupting markdown content. The `create_file` tool writes bytes directly to disk without any shell interpretation, making it the only safe method for PR bodies that contain markdown with backticks or `[ ]` / `[x]` checkbox syntax.
+
+   **In the "Docs outline" section of the PR body, use plain bullet points** (`-`) for agent-verified items, not `- [x]` checkboxes. Reserve `- [ ]` checkboxes only for the "Items needing review" section so reviewers know exactly which items require their action.
+
 6. In the PR body, notify the spec author using the handle from Step 2:
    - If a valid GitHub handle was found: include `/cc @<engineer-handle>`
    - If the fallback placeholder was produced: include the literal text `[TODO: tag spec author]` — do not wrap it in `/cc @`, as that would produce a malformed mention

--- a/.agents/skills/write-feature-docs/SKILL.md
+++ b/.agents/skills/write-feature-docs/SKILL.md
@@ -50,11 +50,35 @@ Things to verify from code:
 - **CLI commands or keyboard shortcuts** mentioned in the spec
 - **Related features**: identify other features that cross-reference this one for "Related pages"
 - **Engineer to tag**: identify the GitHub handle of the engineer who owns the spec.
-  - *Interactive mode*: run `gh api user --jq .login` to get the handle of the person currently running the skill — they are the engineer.
-  - *Ambient mode*: before running any lookup commands, validate that the spec ID contains only alphanumeric characters and hyphens (matching `^[A-Za-z0-9][A-Za-z0-9-]*$`). If the spec ID contains any other characters, skip the lookup entirely and use `[TODO: tag spec author]` as a placeholder — do not interpolate an unvalidated spec ID into a shell command. If the spec ID is valid, assign it to a shell variable (`SPEC_ID="<spec-id>"`) and use that variable in quoted form throughout:
-    1. `gh pr list --search "specs/${SPEC_ID}" --repo warpdotdev/warp-internal --state merged --json author --limit 1 --jq '.[0].author.login // empty'`
-    2. If that returns empty (e.g. the repo uses a sync bot), capture the commit author email first: `EMAIL=$(git log --follow -1 --pretty=format:"%ae" -- "specs/${SPEC_ID}/PRODUCT.md")` — then, only if `${EMAIL}` is non-empty, resolve it to a handle: `gh api "search/users?q=${EMAIL}+in:email" --jq '.items[0].login // empty'`
-    3. If the handle still can't be determined, use `[TODO: tag spec author]` as a placeholder in the PR body.
+  - *Interactive mode*: run `gh api user --jq .login` to get the handle of the person currently running the skill — use this only when the skill is being invoked directly by the spec engineer. If a docs team member or non-author is running the skill, use the discovery steps below instead.
+  - *Ambient mode and non-author interactive runs*: before running any lookup commands, validate that the spec ID contains only alphanumeric characters and hyphens (matching `^[A-Za-z0-9][A-Za-z0-9-]*$`). If the spec ID contains any other characters, skip the lookup entirely and use `[TODO: tag spec author]` as a placeholder. If the spec ID is valid, assign it to `SPEC_ID` and work through these steps in order, stopping as soon as a handle is found:
+    1. **Check `Co-authored-by:` trailers in the commit message** — in repos that mirror from a private source (like `warp-internal`), the sync bot is the commit author but the real author appears in a `Co-authored-by:` trailer. Extract the first non-bot entry:
+       ```bash
+       git log --follow -1 --format="%B" -- "specs/${SPEC_ID}/PRODUCT.md" \
+         | grep -i "^Co-authored-by:" \
+         | grep -v "\[bot\]" \
+         | head -1 \
+         | grep -oP '<[^>]+>' | tr -d '<>'
+       ```
+       This returns an email (possibly a GitHub noreply address). If the email matches the pattern `<userid>+<username>@users.noreply.github.com`, extract the handle directly: `echo "$EMAIL" | grep -oP '\+\K[^@]+'`. If it's a real email, resolve it via `gh api "search/users?q=${EMAIL}+in:email" --jq '.items[0].login'`.
+    2. **Parse the synced-from PR URL** — some sync bots embed the original PR URL in the commit body (e.g. `Synced from warp: https://github.com/warpdotdev/warp/pull/11901`). Extract it and fetch the PR author:
+       ```bash
+       ORIG_PR=$(git log --follow -1 --format="%B" -- "specs/${SPEC_ID}/PRODUCT.md" \
+         | grep -oP 'https://github\.com/[^/]+/[^/]+/pull/\d+' | head -1)
+       # Extract owner/repo and PR number, then: gh pr view <N> --repo <owner/repo> --json author --jq '.author.login'
+       ```
+    3. **Search the origin repo PRs** — try the repo that actually owns the code (checking both the public mirror and the private source if accessible):
+       ```bash
+       gh pr list --search "specs/${SPEC_ID}" --repo warpdotdev/warp-internal --state merged --json author --limit 1 --jq '.[0].author.login'
+       # Also try: gh pr list --search "specs/${SPEC_ID}" --repo warpdotdev/warp --state merged --json author --limit 1 --jq '.[0].author.login'
+       ```
+       Skip any result where the login contains `[bot]`.
+    4. **Fall back to commit author email** — only if the email does NOT contain `[bot]`:
+       ```bash
+       EMAIL=$(git log --follow -1 --pretty=format:"%ae" -- "specs/${SPEC_ID}/PRODUCT.md")
+       ```
+       If `${EMAIL}` is non-empty and bot-free, resolve it to a handle via `gh api "search/users?q=${EMAIL}+in:email" --jq '.items[0].login'`.
+    5. If no handle is found after all steps, use `[TODO: tag spec author]` as a placeholder in the PR body.
 
 For each claim you verify from code, mark it confirmed. For claims you can't verify (UI behavior not in code, product intent, behavior of unreleased features), flag them as `[UNVERIFIED]` in the outline — those are the only things the engineer needs to focus on.
 


### PR DESCRIPTION
## What

Follow-up to #38. Improvements discovered during dogfooding the `write-feature-docs` skill end-to-end (dry run + demo + review iterations).

## write-feature-docs changes

**Security**
- Validate spec ID against `^[A-Za-z0-9][A-Za-z0-9-]*$` before interpolating into any shell command in ambient-mode engineer lookup. Invalid IDs fall back immediately to `[TODO: tag spec author]`.
- Quote feature flag search term via a `FEATURE` shell variable rather than raw interpolation.
- Fix unassigned `EMAIL` variable: capture `git log` output into `EMAIL=$(git log ...)` before using it in `gh api` search; skip the search if `EMAIL` is empty.

**Bug fixes**
- Fix `/cc` fallback: distinguish a resolved handle (`/cc @<handle>`) from the `[TODO: tag spec author]` fallback (literal text, not wrapped in `/cc @` which would produce a malformed mention).
- Write PR body to a temp file and use `--body-file` instead of shell string interpolation — prevents corruption of markdown content (backticks, `$vars`, `[ ]` glob patterns) observed in practice. Instruction is now tool-agnostic: any file-writing method works; the requirement is `--body-file`, not a specific tool.
- Use plain bullets (`-`) for agent-verified outline items; reserve `- [ ]` only for items needing reviewer action.

**Engineer discovery (root-cause fix for test run failure)**

The test run couldn't find the engineer for APP-4617 because `warp-internal` uses a sync bot (`warp-repo-sync[bot]`) as the commit author, hiding the real author. Investigation revealed the answer was in the commit message all along:

```
Co-authored-by: Harry Albert <65182701+harryalbert@users.noreply.github.com>
Synced from warp: https://github.com/warpdotdev/warp/pull/11901
```

Four improvements to the discovery chain:
- **Check `Co-authored-by:` trailers first** — sync bots preserve the real author here. This alone would have resolved `harryalbert` for APP-4617.
- **Parse GitHub noreply emails directly** — `<userid>+<username>@users.noreply.github.com` contains the handle without an API call.
- **Parse the synced-from PR URL** — many sync commits embed the original private PR URL, which can be used to fetch the PR author directly.
- **Bot email detection** — skip the `gh api` email lookup when the commit author email contains `[bot]`; the previous code wasted an API call on the bot address before failing.
- **Interactive mode clarification** — `gh api user` returns the running user, which is wrong when a docs team member runs the skill on behalf of an engineer. Added a note to use discovery steps in that case.

**Content (11 fixes from top-to-bottom review)**
- Fix workflow overview step numbering to match body (1–5 with 4.5)
- Expand spec ID format examples to include `REMOTE-1234`, `QUALITY-408`
- Mark TECH.md review step as interactive-mode only with ambient cross-reference
- Add outline template flexibility note (sections are defaults, not a rigid skeleton)
- Fix `:::tip` description to "helpful hints and best practices"
- Fix screenshot asset path: instruct agent to calculate relative depth
- Specify sidebar entry format with concrete TypeScript example
- Replace `git/trees/HEAD?recursive=1` with `gh api .../contents/specs`
- Fix ambient mode outline template: use `<engineer-handle>` with substitution reminder
- Restore `write-product-spec` and `write-tech-spec` to Related skills (both exist)

## scan-new-specs changes

- Remove `@petradonka` from PR reviewers in Path A (Step 4)
- Confirm `#growth-docs` as the permanent Slack channel (remove TODO note)

Co-Authored-By: Oz <oz-agent@warp.dev>
