### PR TITLE
Add deterministic Vercel publishing to readout

### DIFF
--- a/.agents/skills/readout/SKILL.md
+++ b/.agents/skills/readout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: readout
-description: Produce a polished, self-contained HTML "readout" document under ~/.readouts (with an auto-maintained index page), either by snapshotting the findings accumulated in the current conversation or — when invoked fresh, e.g. "/readout on how github webhook events are processed" — by sharpening scope with clarifying questions and researching the codebase before documenting. The work runs in a child agent so the main conversation's context stays clean. Use whenever the user invokes /readout, says "write this up", "turn this into a doc/page", "make a readout", or asks for a readable, shareable document capturing findings or explaining how something works.
+description: Produce a polished, self-contained HTML "readout" document under ~/.readouts (with an auto-maintained index page) and optionally publish it to Vercel after explicit user consent. Works by snapshotting the current conversation or researching a fresh question in the codebase, using a child agent so the main conversation stays clean. Use whenever the user invokes /readout, says "write this up", "turn this into a doc/page", "make a readout", or asks for a readable, shareable document capturing findings or explaining how something works.
 ---
 
 # Readout
@@ -20,6 +20,10 @@ A vague brief produces a vague document. Before launching you should be able to 
 
 - Ask 2–4 targeted questions, offering concrete options rather than open prompts — take a quick look at the code or topic first so the options are real (subsystems, entry points, competing concerns). For "/readout on how github webhook events are processed": which direction matters — inbound triggers, post-back, or both? a current-state reference or a gotcha hunt? which repo(s)?
 - Always pin down **depth and audience**: high-level orientation vs. deep mechanics with line-level grounding; personal notes vs. shared with the team.
+- Always pin down **deployment**: local HTML only, or publish publicly with Vercel. Recommend local-only. Never infer consent to publish from words like "shareable" or "for my team."
+- If offering public deployment, say plainly that the generated HTML and its embedded source snippets will be visible to anyone on the internet, and that Vercel Authentication will be disabled for a dedicated readouts project so all current and future deployments in that project are public.
+- After the user selects public Vercel, run `python3 <skill-directory>/scripts/list_vercel_scopes.py`. Present its `scopes` as concrete choices and ask which account/team should own the deployment. Do not guess from the active team or hardcode an organization.
+- Only record `public Vercel (explicitly approved)` after the user approves both public content and disabling protection for the dedicated project, and chooses a scope.
 - Respect a shrug. "Just a high-level overview" is a valid answer — record it in the brief and move on rather than interrogating. Even then, try to extract the two or three questions the reader most needs answered; specificity is what makes a readout useful.
 - Skip the interview when the scope is already specific — a snapshot of a focused conversation, or a precise research request, needs no questions. In snapshot mode the conversation usually supplies the questions; ask only when the invocation is ambiguous about which threads to include.
 
@@ -30,6 +34,8 @@ Write a short brief (roughly 10–20 lines) carrying **pointers, not payloads**:
 - A working title / topic, and the mode (snapshot or research)
 - The specific questions the document must answer (from the conversation or the interview), plus depth and audience
 - Scope: which threads/subsystems to cover, and anything to explicitly exclude
+- Deployment: `local only` or `public Vercel (explicitly approved)`
+- For public Vercel: the exact selected scope slug and, only if requested, a non-default project name
 - Snapshot mode: headline conclusions worth centering the doc on, one line each — the child pulls the full content from conversation history itself, so don't paste findings wholesale
 - Research mode: starting pointers — entry-point files, symbols, or directories you already know about
 - Absolute paths to the repos/directories that ground the work
@@ -44,11 +50,30 @@ Build the child's prompt from the template below. It must include:
 - The brief
 - The source-material block matching the mode (snapshot mode also needs your agent run ID — `current_run_id` from the orchestration runtime context — so the child can mine the parent conversation with `search_conversation_history`)
 - The instruction to read `references/doc-guide.md` from this skill's directory before writing
-- The output path convention and completion protocol
+- The output path convention, deployment choice, and completion protocol
 
-### 4. Get back to work
+### 4. Publish only when explicitly approved
 
-After launching, resume whatever you were doing, or end your turn — the child's completion message arrives on its own; relay the file path to the user with a one-line description when it does. In research mode a fresh conversation may have nothing else pending; just end the turn. Don't sit in a wait loop unless the user asked to wait for the document.
+Local-only is the default. If the brief says `public Vercel (explicitly approved)`, the child publishes the finished file with:
+`python3 <skill-directory>/scripts/publish_vercel.py <doc.html> --scope <approved-scope> --confirm-public --confirm-disable-protection --json`
+
+The helper:
+
+- Requires an installed and authenticated Vercel CLI.
+- Requires an explicit account/team scope returned by `list_vercel_scopes.py`; it has no organization-specific default.
+- Defaults to a collision-resistant `readouts-<vercel-user>` project within that scope.
+- Uses the Vercel API to distinguish a missing project from authentication, permission, and network errors.
+- Creates or links the project non-interactively, records a local managed-project marker, adds only explicitly selected readouts, and regenerates the public index.
+- Refuses to change protection on an existing unmarked project. `--allow-existing-project` is allowed only after the user separately confirms that the named project is dedicated to readouts and contains no unrelated deployments.
+- Disables Vercel Authentication only for the managed project; it does not change scope defaults or other projects.
+- Resolves the production alias instead of returning Vercel's often-protected immutable deployment URL.
+- Runs `verify_public_url.py` anonymously and reports success only after HTTP 200 and an exact `<title>` match.
+
+Before invoking it, inspect the generated document for credentials, tokens, private customer data, or source that should not be public. Embedded snippets are part of the HTML and become public too. If anything looks sensitive or the user's consent is absent or ambiguous, do not publish; return the local file and explain the blocker.
+
+### 5. Get back to work
+
+After launching, resume whatever you were doing, or end your turn — the child's completion message arrives on its own; relay the local file path and, when approved and successfully published, the public URL with a one-line description. In research mode a fresh conversation may have nothing else pending; just end the turn. Don't sit in a wait loop unless the user asked to wait for the document.
 
 ## Child agent prompt template
 
@@ -92,8 +117,18 @@ Output:
   (fully regenerates ~/.readouts/index.html listing every readout).
 - When the file is written, open it with `open <path>` (skip this if the environment is
   headless).
-- Report back to your orchestrator: the absolute file path, a 2–3 sentence summary of what
-  the document covers, and anything you could not verify.
+- Deployment: <local only | public Vercel (explicitly approved)>.
+  Vercel scope: <exact approved scope slug; required for public deployment>.
+  For local only, do not publish. For explicitly approved public deployment, first inspect
+  the final HTML for secrets and private data, then run:
+  python3 <skill-directory>/scripts/publish_vercel.py <doc.html>
+    --scope <approved-scope> --confirm-public --confirm-disable-protection --json
+  Add --project <project-name> only if the brief names a non-default project. Never add
+  --allow-existing-project unless the brief records the user's separate approval to adopt
+  that exact existing project.
+- Report back to your orchestrator: the absolute file path, the public URL if deployed, a
+  2–3 sentence summary of what the document covers, the anonymous verification result,
+  and anything you could not verify.
 ```
 
 ## Fallbacks
@@ -101,3 +136,4 @@ Output:
 - **Child spawning unavailable or denied**: produce the document yourself, following `references/doc-guide.md`. If a research subagent is available, delegate the conversation-mining or code investigation to it so your context still stays lean.
 - **Child can't search conversation history** (snapshot mode; it will report this back): reply to the child with a distilled dump of the findings so it can proceed — this is the one case where payload-in-prompt is the right call.
 - **User-provided material instead of a conversation** (transcripts, files, links): treat that material as the source; everything else in the workflow is unchanged.
+- **Public deployment fails**: keep the local artifact, report the exact deployment or verification error, and do not substitute another hosting provider, return an unverified URL, adopt an existing project, or change deployment visibility without fresh user consent.

--- a/.agents/skills/readout/scripts/list_vercel_scopes.py
+++ b/.agents/skills/readout/scripts/list_vercel_scopes.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""List the authenticated Vercel user and deployable account/team scopes as JSON."""
+
+import json
+import shutil
+import subprocess
+import sys
+
+
+def run(args: list[str]) -> str:
+    result = subprocess.run(args, capture_output=True, text=True)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit code {result.returncode}"
+        raise RuntimeError(f"{' '.join(args)} failed: {detail}")
+    return result.stdout
+
+
+def main() -> int:
+    if shutil.which("vercel") is None:
+        raise RuntimeError("required executable not found: vercel")
+    user = run(["vercel", "whoami", "--no-color"]).strip()
+    if not user:
+        raise RuntimeError("Vercel CLI returned an empty username; run `vercel login`")
+    teams_by_slug = {}
+    cursor = None
+    while True:
+        command = ["vercel", "teams", "ls", "--format=json", "--no-color"]
+        if cursor is not None:
+            command.extend(["--next", str(cursor)])
+        try:
+            team_data = json.loads(run(command))
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("Vercel returned invalid JSON while listing scopes") from exc
+        for team in team_data.get("teams", []):
+            if team.get("slug"):
+                teams_by_slug[team["slug"]] = {
+                    "slug": team["slug"],
+                    "name": team.get("name") or team["slug"],
+                    "current": bool(team.get("current")),
+                }
+        cursor = (team_data.get("pagination") or {}).get("next")
+        if cursor is None:
+            break
+    teams = list(teams_by_slug.values())
+    if not teams:
+        raise RuntimeError("Vercel returned no deployable account/team scopes")
+    print(json.dumps({"authenticated_user": user, "scopes": teams}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/.agents/skills/readout/scripts/publish_vercel.py
+++ b/.agents/skills/readout/scripts/publish_vercel.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Publish one readout through a dedicated Vercel project.
+
+The script intentionally requires --confirm-public because the HTML and any
+embedded source snippets become visible to anyone on the internet.
+
+Usage:
+  python3 publish_vercel.py <doc.html> --scope account-or-team \
+    --confirm-public --confirm-disable-protection
+  python3 publish_vercel.py <doc.html> --scope account-or-team --dry-run
+"""
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+from urllib.parse import quote
+
+
+NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,99}$")
+URL_RE = re.compile(r"https://[^\s]+")
+MANAGED_MARKER = ".readout-managed.json"
+
+
+class PublishError(RuntimeError):
+    pass
+
+
+def run(
+    args: list[str],
+    *,
+    cwd: Optional[Path] = None,
+    check: bool = True,
+    input_text: Optional[str] = None,
+) -> subprocess.CompletedProcess:
+    result = subprocess.run(args, cwd=cwd, capture_output=True, text=True, input=input_text)
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit code {result.returncode}"
+        raise PublishError(f"{' '.join(args)} failed: {detail}")
+    return result
+
+
+def vercel_user() -> str:
+    result = run(["vercel", "whoami", "--no-color"])
+    user = result.stdout.strip()
+    if not user:
+        raise PublishError("Vercel CLI returned an empty username; run `vercel login`")
+    return user
+
+
+def project_name(user: str) -> str:
+    slug = re.sub(r"[^a-z0-9-]+", "-", user.lower()).strip("-")
+    if not slug:
+        raise PublishError(f"could not derive a Vercel project name from username {user!r}")
+    return f"readouts-{slug}"[:100].rstrip("-")
+
+
+def parse_json(result: subprocess.CompletedProcess, action: str) -> dict:
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise PublishError(f"Vercel returned invalid JSON while {action}") from exc
+
+
+def is_not_found(result: subprocess.CompletedProcess) -> bool:
+    detail = f"{result.stderr}\n{result.stdout}"
+    return "HTTP 404" in detail or "not found" in detail.lower()
+
+
+def inspect_project(scope: str, project: str) -> Optional[dict]:
+    result = run(
+        ["vercel", "api", f"/v9/projects/{project}", "--scope", scope, "--raw", "--no-color"],
+        check=False,
+    )
+    if result.returncode == 0:
+        return parse_json(result, f"inspecting project {scope}/{project}")
+    if is_not_found(result):
+        return None
+    detail = result.stderr.strip() or result.stdout.strip()
+    raise PublishError(
+        f"could not inspect Vercel project {scope}/{project}: {detail}. "
+        "Check `vercel login`, the selected scope, permissions, and network access."
+    )
+
+
+def create_project(scope: str, project: str) -> dict:
+    result = run(
+        [
+            "vercel", "api", "/v11/projects", "--scope", scope,
+            "--method", "POST", "--input", "-", "--raw", "--no-color",
+        ],
+        input_text=json.dumps({"name": project, "ssoProtection": None}),
+    )
+    return parse_json(result, f"creating project {scope}/{project}")
+
+
+def marker_matches(site: Path, scope: str, project: str, project_info: dict) -> bool:
+    marker = site / MANAGED_MARKER
+    if marker.is_file():
+        try:
+            data = json.loads(marker.read_text())
+        except json.JSONDecodeError:
+            return False
+        return (
+            data.get("scope") == scope
+            and data.get("project") == project
+            and data.get("project_id") == project_info.get("id")
+        )
+
+    linked = site / ".vercel" / "project.json"
+    if linked.is_file():
+        try:
+            linked_data = json.loads(linked.read_text())
+        except json.JSONDecodeError:
+            return False
+        return linked_data.get("projectId") == project_info.get("id")
+    return False
+
+
+def write_marker(site: Path, scope: str, project: str, project_info: dict) -> None:
+    (site / MANAGED_MARKER).write_text(
+        json.dumps(
+            {
+                "scope": scope,
+                "project": project,
+                "project_id": project_info.get("id"),
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def ensure_public_project(scope: str, project: str) -> None:
+    run(
+        [
+            "vercel", "api", f"/v9/projects/{project}", "--scope", scope,
+            "--method", "PATCH", "--input", "-", "--silent", "--no-color",
+        ],
+        input_text=json.dumps({"ssoProtection": None}),
+    )
+
+
+def prepare_site(doc: Path, scope: str, project: str, skill_dir: Path) -> Path:
+    site = Path.home() / ".readouts" / ".publish" / "vercel" / scope / project
+    site.mkdir(parents=True, exist_ok=True)
+    (site / ".vercelignore").write_text(f"{MANAGED_MARKER}\n")
+    shutil.copy2(doc, site / doc.name)
+    run(["python3", str(skill_dir / "update_index.py"), str(site)])
+
+    link = run([
+        "vercel", "link", "--yes", "--team", scope, "--project", project,
+        "--cwd", str(site), "--no-color",
+    ])
+    if not (site / ".vercel" / "project.json").is_file():
+        detail = link.stderr.strip() or link.stdout.strip()
+        raise PublishError(f"Vercel linked {scope}/{project} but did not create project metadata: {detail}")
+    return site
+
+
+def deploy(site: Path, scope: str) -> str:
+    result = run([
+        "vercel", "deploy", "--prod", "--yes", "--scope", scope,
+        "--cwd", str(site), "--no-color",
+    ])
+    urls = URL_RE.findall(result.stdout)
+    if not urls:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise PublishError(f"Vercel deployment succeeded but returned no deployment URL: {detail}")
+    return urls[-1].rstrip("/")
+
+
+def public_alias(deployment_url: str, scope: str, project: str) -> str:
+    result = run([
+        "vercel", "inspect", deployment_url, "--scope", scope,
+        "--format=json", "--no-color",
+    ])
+    try:
+        aliases = json.loads(result.stdout).get("aliases") or []
+    except json.JSONDecodeError as exc:
+        raise PublishError("Vercel returned invalid JSON while resolving the public alias") from exc
+    preferred = f"{project}.vercel.app"
+    if preferred in aliases:
+        return f"https://{preferred}"
+    if aliases:
+        return f"https://{min(aliases, key=len)}"
+    raise PublishError(f"Vercel deployment {deployment_url} has no production alias")
+
+
+def verify_public_url(public_url: str, doc: Path, skill_dir: Path) -> dict:
+    result = run([
+        "python3", str(skill_dir / "verify_public_url.py"), public_url,
+        "--expected-file", str(doc), "--json",
+    ])
+    return parse_json(result, f"verifying public URL {public_url}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("doc", type=Path, help="self-contained readout HTML file")
+    parser.add_argument("--scope", required=True, help="Vercel account/team slug from list_vercel_scopes.py")
+    parser.add_argument("--project", help="Vercel project (default: readouts-<vercel-user>)")
+    parser.add_argument(
+        "--confirm-public",
+        action="store_true",
+        help="confirm that the document and embedded source may be publicly accessible",
+    )
+    parser.add_argument(
+        "--confirm-disable-protection",
+        action="store_true",
+        help="confirm that Vercel Authentication may be disabled for the dedicated project",
+    )
+    parser.add_argument(
+        "--allow-existing-project",
+        action="store_true",
+        help="adopt an existing unmarked project after separately confirming it is dedicated to readouts",
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable deployment details")
+    parser.add_argument("--dry-run", action="store_true", help="validate inputs and print the intended deployment")
+    args = parser.parse_args()
+
+    doc = args.doc.expanduser().resolve()
+    if not doc.is_file() or doc.suffix.lower() != ".html":
+        raise PublishError(f"expected an existing .html file, got {doc}")
+    if not NAME_RE.fullmatch(args.scope):
+        raise PublishError(f"invalid Vercel scope slug: {args.scope}")
+    if not args.dry_run and not args.confirm_public:
+        raise PublishError(
+            "refusing public deployment without --confirm-public; "
+            "the HTML and any embedded source snippets will be visible to anyone"
+        )
+    if not args.dry_run and not args.confirm_disable_protection:
+        raise PublishError(
+            "refusing to change project visibility without --confirm-disable-protection; "
+            "all current and future deployments in the dedicated project will be public"
+        )
+    if not args.dry_run and shutil.which("vercel") is None:
+        raise PublishError("required executable not found: vercel")
+
+    project = args.project
+    if project is None:
+        project = "readouts-<vercel-user>" if args.dry_run else project_name(vercel_user())
+    if project != "readouts-<vercel-user>" and not NAME_RE.fullmatch(project):
+        raise PublishError(f"invalid Vercel project name: {project}")
+
+    if args.dry_run:
+        print(f"Would publicly deploy {doc} to Vercel scope {args.scope}, project {project}.")
+        print(f"The returned URL will use the public production alias and end with /{quote(doc.name)}.")
+        return 0
+
+
+    skill_dir = Path(__file__).resolve().parent
+    site = Path.home() / ".readouts" / ".publish" / "vercel" / args.scope / project
+    site.mkdir(parents=True, exist_ok=True)
+    project_info = inspect_project(args.scope, project)
+    created = project_info is None
+    if created:
+        project_info = create_project(args.scope, project)
+        write_marker(site, args.scope, project, project_info)
+    elif marker_matches(site, args.scope, project, project_info):
+        write_marker(site, args.scope, project, project_info)
+    elif args.allow_existing_project:
+        write_marker(site, args.scope, project, project_info)
+    else:
+        raise PublishError(
+            f"refusing to modify existing unmarked project {args.scope}/{project}; "
+            "use the default dedicated project, or pass --allow-existing-project only "
+            "after confirming the project contains no unrelated deployments"
+        )
+
+    ensure_public_project(args.scope, project)
+    site = prepare_site(doc, args.scope, project, skill_dir)
+    deployment_url = deploy(site, args.scope)
+    alias_url = public_alias(deployment_url, args.scope, project)
+    public_url = f"{alias_url}/{quote(doc.name)}"
+    verification = verify_public_url(public_url, doc, skill_dir)
+    output = {
+        "document": str(doc),
+        "scope": args.scope,
+        "project": project,
+        "project_created": created,
+        "public_url": public_url,
+        "public_index": f"{alias_url}/",
+        "verification": verification,
+    }
+    if args.json:
+        print(json.dumps(output, indent=2))
+    else:
+        print(f"Published {doc}")
+        print(f"Public URL: {public_url}")
+        print(f"Public index: {alias_url}/")
+        print(f"Anonymous verification: HTTP {verification['status']}, title matched")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except PublishError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/.agents/skills/readout/scripts/verify_public_url.py
+++ b/.agents/skills/readout/scripts/verify_public_url.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Verify that a deployed readout is anonymously accessible and has the expected title."""
+
+import argparse
+import html
+import json
+import re
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+
+TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+MAX_HEAD_BYTES = 512 * 1024
+
+
+class VerificationError(RuntimeError):
+    pass
+
+
+def extract_title(source: str) -> str:
+    match = TITLE_RE.search(source)
+    if not match:
+        raise VerificationError("document has no <title>")
+    return html.unescape(re.sub(r"\s+", " ", match.group(1))).strip()
+
+
+def expected_title(path: Path) -> str:
+    return extract_title(path.read_text(errors="replace"))
+
+
+def verify(url: str, title: str, timeout: float) -> dict:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise VerificationError(f"expected an absolute HTTP(S) URL, got {url!r}")
+    request = Request(url, headers={"User-Agent": "Warp-Readout-Public-Verification/1.0"})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            status = response.status
+            final_url = response.geturl()
+            body = response.read(MAX_HEAD_BYTES).decode("utf-8", errors="replace")
+    except HTTPError as exc:
+        raise VerificationError(f"anonymous request returned HTTP {exc.code}") from exc
+    except URLError as exc:
+        raise VerificationError(f"anonymous request failed: {exc.reason}") from exc
+    if status != 200:
+        raise VerificationError(f"anonymous request returned HTTP {status}")
+    final_host = (urlparse(final_url).hostname or "").lower()
+    if final_host == "vercel.com" or final_host.endswith(".vercel.com"):
+        raise VerificationError(f"anonymous request redirected to Vercel authentication: {final_url}")
+    remote_title = extract_title(body)
+    if remote_title != title:
+        raise VerificationError(
+            f"remote title mismatch: expected {title!r}, received {remote_title!r}"
+        )
+    return {
+        "url": url,
+        "final_url": final_url,
+        "status": status,
+        "title": remote_title,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("url", help="public readout URL")
+    expected = parser.add_mutually_exclusive_group(required=True)
+    expected.add_argument("--expected-file", type=Path, help="local HTML whose title must match")
+    expected.add_argument("--expected-title", help="exact expected HTML title")
+    parser.add_argument("--timeout", type=float, default=20.0)
+    parser.add_argument("--json", action="store_true", help="emit machine-readable verification details")
+    args = parser.parse_args()
+
+    if args.expected_file:
+        expected_file = args.expected_file.expanduser()
+        if not expected_file.is_file():
+            raise VerificationError(f"expected HTML file does not exist: {expected_file}")
+        title = expected_title(expected_file)
+    else:
+        title = args.expected_title
+    result = verify(args.url, title, args.timeout)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Verified public readout: {result['final_url']} ({result['title']})")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except VerificationError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- add explicit public-deployment consent and Vercel scope selection to the readout workflow
- add deterministic helpers for scope discovery, managed-project deployment, production-alias resolution, and anonymous verification
- protect unrelated projects by requiring managed markers and separate adoption consent

## Testing
- parsed all readout Python scripts with Python AST
- ran `publish_vercel.py` in dry-run mode
- anonymously verified a deployed readout returns HTTP 200 with an exact title match
- ran `git diff --check`
- exercised the publisher end to end against the managed `warpdotdev/readouts-sathvik-9321` project

Agent Mode: [conversation](https://staging.warp.dev/conversation/f786bebf-94d4-4ec1-8008-c4f3e41a3e6b)

Co-Authored-By: Oz <oz-agent@warp.dev>