### PR TITLE
feat: add evidence-backed false-positive rules to review-pr skill

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -26,6 +26,9 @@ Review the current pull request and write the output to `review.json`.
 - If a concern involves untouched code, mention it in top-level `body` instead of an inline comment.
 - Do not suggest adding test cases that only vary constructor inputs or struct fields when the existing test already covers the meaningful behavior. Only suggest new tests when they exercise a distinct code path or edge case.
 - When a PR is clearly a V0 or initial implementation, frame robustness suggestions (timeouts, retries, lifecycle management) as optional future work rather than blocking concerns, unless they risk correctness, security, or data loss.
+- Do not flag issues in generated files (for example `*.gen.go`, `*_gen.go`, or files carrying a generated-code header) as if they were hand-maintained. Generators rename and update all variants together, so apparent breakages or renamed identifiers there are usually intended codegen output rather than a defect introduced by the PR.
+- Before flagging a state-dependent bug (duplicate or stale selections, missing input masking, a missing guard), confirm it is actually reachable given the current control flow and existing global safeguards. If the current flow already prevents it and the concern only protects a hypothetical future caller, omit it or downgrade to a `💡 [SUGGESTION]` framed as optional defense-in-depth.
+- When raising an authorization or data-scoping concern, first trace how the identifier reaches the code path and whether it is already viewer- or principal-scoped (for example, objects that only enter the graph through viewer-scoped fields), and account for domain invariants that may make the scenario impossible. Do not assert a `🚨 [CRITICAL]` or `⚠️ [IMPORTANT]` security hole unless the untrusted entry path is confirmed; when it is unverified, raise it as an open question in the top-level `body` instead of an inline assertion, or omit it.
 
 ## Repository-specific guidance
 


### PR DESCRIPTION
## Summary

Refines the shared `review-pr` skill using real reviewer feedback aggregated by the `update-pr-review` workflow over the recent warp-server PR window. The analysis surfaced recurring cases where humans overrode the review bot (`oz-for-oss` / `warp-dev-github-integration`) as false positives, while its security/correctness findings (shell injection, error leakage, lock races) were consistently validated and addressed — so this change targets precision, not weakening genuine checks.

## Changes

Adds three evidence-backed bullets to the **Review Scope** section:

1. **Generated files** — don't review `*.gen.go` / generated-header files as hand-maintained; renamed identifiers are intended codegen output. _(Evidence: warp-server #13249, maintainer: `@captainsafia` — "This isn't actually a real issue. This is the types generator...")_
2. **Reachability / global safeguards** — verify a state-dependent bug is actually reachable given current control flow and existing global safeguards before flagging; downgrade hypothetical-future-caller concerns to optional defense-in-depth. _(Evidence: #13201 and #13175, reviewer `@johnturcoo`.)_
3. **Authorization / data-scoping** — trace whether the identifier is already viewer/principal-scoped and account for domain invariants before asserting a security hole; raise unverified concerns as open questions instead of inline `🚨`/`⚠️` assertions. _(Evidence: #13184 ×3, reviewer `@yuanben-warp`.)_

## Notes

- All qualifying feedback came from **code** PRs (0 spec-only PRs), so `review-spec` is intentionally unchanged.
- The `review-pr` skill lives here in `common-skills` (migrated out of `warp-server`); the `update-pr-review` workflow that produced this analysis still lives in `warp-server`.

cc @captainsafia


---
_Conversation: https://staging.warp.dev/conversation/88890f9f-352d-4594-840c-a75b2db92c33_
_Run: https://oz.staging.warp.dev/runs/019f94a4-1135-79f6-b922-a465ed938d40_

_This PR was generated with [Oz](https://warp.dev/oz)._
