### PR TITLE
feat(review-pr): require evidence for security and unwired-UI findings

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -26,6 +26,8 @@ Review the current pull request and write the output to `review.json`.
 - If a concern involves untouched code, mention it in top-level `body` instead of an inline comment.
 - Do not suggest adding test cases that only vary constructor inputs or struct fields when the existing test already covers the meaningful behavior. Only suggest new tests when they exercise a distinct code path or edge case.
 - When a PR is clearly a V0 or initial implementation, frame robustness suggestions (timeouts, retries, lifecycle management) as optional future work rather than blocking concerns, unless they risk correctness, security, or data loss.
+- Before filing a sensitive-data-exposure, injection, or encoding finding, trace how the value is actually produced in this repository. If no concrete path admits the hazardous input, drop the finding or raise it as an open question in top-level `body` instead of asserting it as a `[SECURITY]` issue. Reviewers consistently reject speculative "this string could contain secrets" and "this identifier could contain a path separator" claims when the producing code makes that impossible.
+- Treat an interactive element with no handler in a UI PR (a button, menu item, or action that does nothing) as a likely intentional placeholder for a follow-up PR. Use at most `💡 [SUGGESTION]`, or raise it in top-level `body`, unless the PR description or the code claims the behavior already works.
 
 ## Repository-specific guidance
 


### PR DESCRIPTION
Ran the `update-pr-review` skill over the last 7 days of `warpdotdev/warp-server` pull requests (100 PRs, 82 review threads, 13 agent review comments that drew human replies) and folded the repeated reviewer signals back into the shared `review-pr` skill.

All PRs in the window were code PRs (`review_type: "code"`), so `review-spec` is unchanged.

## Signals

**1. Speculative security findings get rejected (3 threads, 3 reviewers).**

- [#13603](https://github.com/warpdotdev/warp-server/pull/13603) — `⚠️ [IMPORTANT] [SECURITY]` claimed logging raw errors could leak secrets. `@seemeroland`: _"I think we need to be able to log errs. If it turns out something sensitive is actually included we should remove it from the err"_.
- [#13588](https://github.com/warpdotdev/warp-server/pull/13588) — same shape, sending a status message to RudderStack. `@seemeroland`: _"I think this is fine"_.
- [#13615](https://github.com/warpdotdev/warp-server/pull/13615) — `⚠️ [IMPORTANT]` asked for `encodeURIComponent` on an agent UID. `@johnturcoo`: _"agent IDs are uuid and uniform"_.

In each case the bot asserted a hazard from a value's *hypothetical* shape without tracing how the value is actually produced. The new rule asks for that trace before filing the finding, and routes unprovable concerns to top-level `body` instead of an asserted `[SECURITY]` inline comment.

This does not weaken genuine findings: the evidence-backed security comments in the same window were accepted ([#13583](https://github.com/warpdotdev/warp-server/pull/13583) cross-team suite ownership — _"Should be fixed now"_; [#13646](https://github.com/warpdotdev/warp-server/pull/13646) empty-owner authorization — _"I think this is kind of valid. Will push a change to address"_).

**2. Unwired UI elements are deliberate placeholders (3 threads, 2 PRs, 1 reviewer).**

- [#13615](https://github.com/warpdotdev/warp-server/pull/13615) `FactoryAgentEditor.tsx` — Reconnect button with no `onPress`. `@johnturcoo`: _"intentional"_.
- [#13601](https://github.com/warpdotdev/warp-server/pull/13601) `index.tsx` — New button with no `onPress`. _"Intentional"_.
- [#13601](https://github.com/warpdotdev/warp-server/pull/13601) `AgentActions.tsx` — Copy-as-JSON menu item with no handler. _"Intentional"_.

Three `[IMPORTANT]`/`[SUGGESTION]` comments, three identical dismissals. This extends the existing V0/initial-implementation rule to UI scaffolding.

## Changes

Two bullets added to `## Review Scope` in `.agents/skills/review-pr/SKILL.md`. No change to the output schema, severity labels, safety rules, or diff-annotation contract.

cc @captainsafia


---

_Conversation: https://staging.warp.dev/conversation/dc738e5e-a8e5-4566-b2d4-29ee96789b37_
_Run: https://oz.staging.warp.dev/runs/019fb8b0-9544-7b70-9887-85d1d17593cc_

_This PR was generated with [Oz](https://warp.dev/oz)._
