### PR TITLE
Curve skill-doctor grades and filter edits by failures

### DIFF
--- a/.agents/skills/skill-doctor/SKILL.md
+++ b/.agents/skills/skill-doctor/SKILL.md
@@ -118,6 +118,7 @@ Then derive the substance:
 ## Step 4: Draft skill edits
 
 Follow `$SKILL_ROOT/references/skill-improvements.md` to propose improvements to project skills based only on `failed_conversations`.
+Every proposed skill patch must follow STE-100: use short, direct, unambiguous instructions and remove unnecessary words.
 
 1. Read the skill's current file (path is in `inventory.json`).
 2. Write the full improved version to `$REPORT_DIR/proposed/<skill-name>/SKILL.md`, changing only what the evidence justifies. Improve the parts the sessions actually exercised: the trigger description that failed to fire, the missing preflight check, the step the agent had to figure out by trial and error.

--- a/.agents/skills/skill-doctor/SKILL.md
+++ b/.agents/skills/skill-doctor/SKILL.md
@@ -94,14 +94,18 @@ Scoring is based on efficiency and code quality for the sessions sampled. Proces
 - `$SKILL_ROOT/scorers/efficiency.md`
 - `$SKILL_ROOT/scorers/code-quality.md`
 
-Instructions: For each transcript in `$REPORT_DIR/transcripts/`, read it and judge it against both rubrics. For each scorer record: label, numeric score (from the rubric's label table), and a 1–3 sentence reason citing specifics from the transcript. Apply the code-quality scorer only where the transcript shows code changes; otherwise record `insufficient_evidence` and exclude that session from the code-quality average.
+Instructions: For each transcript in `$REPORT_DIR/transcripts/`, read it and judge it against both rubrics. For each scorer record: label, numeric score (from the rubric's label table), and a 1–3 sentence reason citing specifics from the transcript. Apply the code-quality scorer only where the transcript shows code changes; otherwise record `insufficient_evidence` and exclude that result from pass/fail aggregation.
 
 ## Step 3: Aggregate
 
-- `efficiency` = mean of efficiency scores across all scored sessions.
-- `code_quality` = mean of code-quality scores, excluding `insufficient_evidence`. If no session had enough evidence, set it to 0.5 and say so in the findings.
+- An efficiency result passes when its numeric score is at least `0.5`; otherwise it fails.
+- A code-quality result passes when its numeric score is at least `0.5`; otherwise it fails. Exclude `insufficient_evidence` results before applying the threshold.
+- `efficiency` = efficiency passes divided by all efficiency results.
+- `code_quality` = code-quality passes divided by all applicable code-quality results. If no session had enough evidence, set it to `null` and say so in the findings.
 - `skill_coverage` = fraction of sampled sessions where at least one installed skill was detected. If `skills_found` is 0, coverage is 0.
-- `overall = 0.5 * efficiency + 0.35 * code_quality + 0.15 * skill_coverage.`
+- `overall` = total efficiency and code-quality passes divided by the total applicable efficiency and code-quality results. Calculate this from the combined pass and fail counts, not by averaging the two category pass rates. Skill coverage is diagnostic and does not affect the grade.
+
+Record the pass and fail counts for `efficiency`, `code_quality`, and `overall` in `score_counts`. For example, four passes and one fail produces an `overall` score of `0.8` and a grade of 80%.
 
 Then derive the substance:
 
@@ -134,7 +138,12 @@ Write `$REPORT_DIR/report.json`:
     "sessions_analyzed": 0, "sessions_scanned": 0,
     "skills_found": 0, "skills_used": 0, "window_days": 45
   },
-  "scores": {"efficiency": 0.0, "code_quality": 0.0, "skill_coverage": 0.0, "overall": 0.0},
+  "scores": {"efficiency": 0.0, "code_quality": null, "skill_coverage": 0.0, "overall": 0.0},
+  "score_counts": {
+    "efficiency": {"passes": 0, "fails": 0},
+    "code_quality": {"passes": 0, "fails": 0},
+    "overall": {"passes": 0, "fails": 0}
+  },
   "top_findings": ["", "", ""],
   "suggestions": [
     {

--- a/.agents/skills/skill-doctor/SKILL.md
+++ b/.agents/skills/skill-doctor/SKILL.md
@@ -106,15 +106,16 @@ Instructions: For each transcript in `$REPORT_DIR/transcripts/`, read it and jud
 - `overall` = total efficiency and code-quality passes divided by the total applicable efficiency and code-quality results. Calculate this from the combined pass and fail counts, not by averaging the two category pass rates. Skill coverage is diagnostic and does not affect the grade.
 
 Record the pass and fail counts for `efficiency`, `code_quality`, and `overall` in `score_counts`. For example, four passes and one fail produces an `overall` score of `0.8` and a grade of 80%.
+Define `failed_conversations` as sampled conversations with at least one applicable efficiency or code-quality score below `0.5`. An `insufficient_evidence` result does not make a conversation fail. Use only `failed_conversations` as evidence for skill-improvement suggestions and draft skill edits; passing conversations can inform the report findings but must not motivate an edit.
 
 Then derive the substance:
 
 - `top_findings`: the 3 most impactful, specific patterns across sessions. These lead the report and the spoken summary. Make each summary concrete and concise, following the STE-100 standard.
-- `suggestions`: concrete skill changes, if any. Each names a skill (existing or proposed-new) and a specific change: a trigger-description fix so it fires when it should, a missing step or check, a command to encode, a new skill to create. Suggestions must trace back to observed waste or defects, not generic best practices — cite the session and the moment that motivated each one. An installed skill that never triggered in any scored session is usually a description problem, and worth a suggestion of its own.
+- `suggestions`: concrete skill changes, if any. Each names a skill (existing or proposed-new) and a specific change: a trigger-description fix so it fires when it should, a missing step or check, a command to encode, a new skill to create. Suggestions must trace back to observed waste or defects in `failed_conversations`, not generic best practices — cite the failed session, scorer, and moment that motivated each one. An installed skill that never triggered in a failed conversation is usually a description problem and worth a suggestion of its own.
 
 ## Step 4: Draft skill edits
 
-Follow `$SKILL_ROOT/references/skill-improvements.md` to propose improvements to project skills based on the aggregated data.
+Follow `$SKILL_ROOT/references/skill-improvements.md` to propose improvements to project skills based only on `failed_conversations`.
 
 1. Read the skill's current file (path is in `inventory.json`).
 2. Write the full improved version to `$REPORT_DIR/proposed/<skill-name>/SKILL.md`, changing only what the evidence justifies. Improve the parts the sessions actually exercised: the trigger description that failed to fire, the missing preflight check, the step the agent had to figure out by trial and error.

--- a/.agents/skills/skill-doctor/SKILL.md
+++ b/.agents/skills/skill-doctor/SKILL.md
@@ -94,19 +94,16 @@ Scoring is based on efficiency and code quality for the sessions sampled. Proces
 - `$SKILL_ROOT/scorers/efficiency.md`
 - `$SKILL_ROOT/scorers/code-quality.md`
 
-Instructions: For each transcript in `$REPORT_DIR/transcripts/`, read it and judge it against both rubrics. For each scorer record: label, numeric score (from the rubric's label table), and a 1–3 sentence reason citing specifics from the transcript. Apply the code-quality scorer only where the transcript shows code changes; otherwise record `insufficient_evidence` and exclude that result from pass/fail aggregation.
+Instructions: For each transcript in `$REPORT_DIR/transcripts/`, read it and judge it against both rubrics. For each scorer record: label, numeric score (from the rubric's label table), and a 1–3 sentence reason citing specifics from the transcript. Apply the code-quality scorer only where the transcript shows code changes; otherwise record `insufficient_evidence` and exclude that result from the code-quality average and failed-conversation filter.
 
 ## Step 3: Aggregate
 
-- An efficiency result passes when its numeric score is at least `0.5`; otherwise it fails.
-- A code-quality result passes when its numeric score is at least `0.5`; otherwise it fails. Exclude `insufficient_evidence` results before applying the threshold.
-- `efficiency` = efficiency passes divided by all efficiency results.
-- `code_quality` = code-quality passes divided by all applicable code-quality results. If no session had enough evidence, set it to `null` and say so in the findings.
+- `efficiency` = mean of efficiency scores across all scored sessions.
+- `code_quality` = mean of code-quality scores, excluding `insufficient_evidence`. If no session had enough evidence, set it to 0.5 and say so in the findings.
 - `skill_coverage` = fraction of sampled sessions where at least one installed skill was detected. If `skills_found` is 0, coverage is 0.
-- `overall` = total efficiency and code-quality passes divided by the total applicable efficiency and code-quality results. Calculate this from the combined pass and fail counts, not by averaging the two category pass rates. Skill coverage is diagnostic and does not affect the grade.
+- `overall = 0.5 * efficiency + 0.35 * code_quality + 0.15 * skill_coverage.`
 
-Record the pass and fail counts for `efficiency`, `code_quality`, and `overall` in `score_counts`. For example, four passes and one fail produces an `overall` score of `0.8` and a grade of 80%.
-Define `failed_conversations` as sampled conversations with at least one applicable efficiency or code-quality score below `0.5`. An `insufficient_evidence` result does not make a conversation fail. Use only `failed_conversations` as evidence for skill-improvement suggestions and draft skill edits; passing conversations can inform the report findings but must not motivate an edit.
+Separately from report aggregation, define `failed_conversations` as sampled conversations with at least one applicable efficiency or code-quality score below `0.5`. An `insufficient_evidence` result does not make a conversation fail. Use only `failed_conversations` as evidence for skill-improvement suggestions and draft skill edits; passing conversations can inform the report findings but must not motivate an edit.
 
 Then derive the substance:
 
@@ -139,12 +136,7 @@ Write `$REPORT_DIR/report.json`:
     "sessions_analyzed": 0, "sessions_scanned": 0,
     "skills_found": 0, "skills_used": 0, "window_days": 45
   },
-  "scores": {"efficiency": 0.0, "code_quality": null, "skill_coverage": 0.0, "overall": 0.0},
-  "score_counts": {
-    "efficiency": {"passes": 0, "fails": 0},
-    "code_quality": {"passes": 0, "fails": 0},
-    "overall": {"passes": 0, "fails": 0}
-  },
+  "scores": {"efficiency": 0.0, "code_quality": 0.0, "skill_coverage": 0.0, "overall": 0.0},
   "top_findings": ["", "", ""],
   "suggestions": [
     {

--- a/.agents/skills/skill-doctor/SKILL.md
+++ b/.agents/skills/skill-doctor/SKILL.md
@@ -98,12 +98,17 @@ Instructions: For each transcript in `$REPORT_DIR/transcripts/`, read it and jud
 
 ## Step 3: Aggregate
 
-- `efficiency` = mean of efficiency scores across all scored sessions.
-- `code_quality` = mean of code-quality scores, excluding `insufficient_evidence`. If no session had enough evidence, set it to 0.5 and say so in the findings.
+- `raw_efficiency` = mean of efficiency scores across all scored sessions.
+- `raw_code_quality` = mean of code-quality scores, excluding `insufficient_evidence`. If no session had enough evidence, set it to 0.5 and say so in the findings.
+- Curve qualitative rubric means into letter-grade report scores with `curve(score) = 0.5 + 0.5 * score`.
+- `efficiency = curve(raw_efficiency)`.
+- `code_quality = curve(raw_code_quality)`.
 - `skill_coverage` = fraction of sampled sessions where at least one installed skill was detected. If `skills_found` is 0, coverage is 0.
 - `overall = 0.5 * efficiency + 0.35 * code_quality + 0.15 * skill_coverage.`
 
-Separately from report aggregation, define `failed_conversations` as sampled conversations with at least one applicable efficiency or code-quality score below `0.5`. An `insufficient_evidence` result does not make a conversation fail. Use only `failed_conversations` as evidence for skill-improvement suggestions and draft skill edits; passing conversations can inform the report findings but must not motivate an edit.
+The curve maps raw scores of `1.0`, `0.8`, `0.4`, and `0.2` to report scores of `1.0`, `0.9`, `0.7`, and `0.6`. Keep `skill_coverage` literal because it is an observed fraction, not a qualitative rubric score.
+
+Separately from report aggregation, define `failed_conversations` from each conversation's raw, uncurved scorer results. A conversation fails when at least one applicable efficiency or code-quality score is below `0.5`. An `insufficient_evidence` result does not make a conversation fail. Use only `failed_conversations` as evidence for skill-improvement suggestions and draft skill edits; passing conversations can inform the report findings but must not motivate an edit.
 
 Then derive the substance:
 
@@ -123,8 +128,7 @@ For a proposed-new skill, write the complete new SKILL.md to the same `proposed/
 Do not modify the user's real skill files in this step.
 
 ## Step 5: Write report.json and render
-
-Write `$REPORT_DIR/report.json`:
+Write `$REPORT_DIR/report.json`. Store the curved `efficiency` and `code_quality` values, literal `skill_coverage`, and weighted `overall` in `scores`; do not store the raw rubric means there.
 
 ```json
 {

--- a/.agents/skills/skill-doctor/SKILL.md
+++ b/.agents/skills/skill-doctor/SKILL.md
@@ -106,9 +106,7 @@ Instructions: For each transcript in `$REPORT_DIR/transcripts/`, read it and jud
 - `skill_coverage` = fraction of sampled sessions where at least one installed skill was detected. If `skills_found` is 0, coverage is 0.
 - `overall = 0.5 * efficiency + 0.35 * code_quality + 0.15 * skill_coverage.`
 
-The curve maps raw scores of `1.0`, `0.8`, `0.4`, and `0.2` to report scores of `1.0`, `0.9`, `0.7`, and `0.6`. Keep `skill_coverage` literal because it is an observed fraction, not a qualitative rubric score.
-
-Separately from report aggregation, define `failed_conversations` from each conversation's raw, uncurved scorer results. A conversation fails when at least one applicable efficiency or code-quality score is below `0.5`. An `insufficient_evidence` result does not make a conversation fail. Use only `failed_conversations` as evidence for skill-improvement suggestions and draft skill edits; passing conversations can inform the report findings but must not motivate an edit.
+Then, define `failed_conversations` from each conversation's raw, uncurved scorer results. A conversation fails when at least one applicable efficiency or code-quality score is below `0.5`. An `insufficient_evidence` result does not make a conversation fail. Use only `failed_conversations` as evidence for skill-improvement suggestions and draft skill edits.
 
 Then derive the substance:
 
@@ -118,7 +116,6 @@ Then derive the substance:
 ## Step 4: Draft skill edits
 
 Follow `$SKILL_ROOT/references/skill-improvements.md` to propose improvements to project skills based only on `failed_conversations`.
-Every proposed skill patch must follow STE-100: use short, direct, unambiguous instructions and remove unnecessary words.
 
 1. Read the skill's current file (path is in `inventory.json`).
 2. Write the full improved version to `$REPORT_DIR/proposed/<skill-name>/SKILL.md`, changing only what the evidence justifies. Improve the parts the sessions actually exercised: the trigger description that failed to fire, the missing preflight check, the step the agent had to figure out by trial and error.

--- a/.agents/skills/skill-doctor/SKILL.md
+++ b/.agents/skills/skill-doctor/SKILL.md
@@ -154,18 +154,18 @@ Write `$REPORT_DIR/report.json`. Store the curved `efficiency` and `code_quality
 ```
 
 ```bash
-python3 "$SKILL_ROOT/scripts/render_report.py" "$REPORT_DIR/report.json"
+python3 "$SKILL_ROOT/scripts/render_report.py" "$REPORT_DIR/report.json" --open
 ```
 
-This writes a single self-contained `$REPORT_DIR/report.html`: the scorecard, findings, and suggested skill edits on one page. Long diffs are collapsed behind a "show more" toggle, and a "share as png" button exports a 1200x675 share image locally. There is no separate card file to open or screenshot.
+This writes a single self-contained `$REPORT_DIR/report.html` and attempts to open it in the default browser. The scorecard, findings, and suggested skill edits appear on one page. Long diffs are collapsed behind a "show more" toggle, and a "share as png" button exports a 1200x675 share image locally. There is no separate card file to open or screenshot.
 
 ## Step 6: Output
 
 Tell the user the grade and the three findings, in text.
 
-Finish every response with this exact linked summary, substituting the absolute `REPORT_DIR` path so the link is clickable:
+Finish every response with this exact summary, substituting the absolute `REPORT_DIR` path:
 
-- Your agent skill report: [View in browser](file://$REPORT_DIR/report.html)
-- Want to automate self improvement for your workflows? [Request access to Warp Factories](https://warp.dev/factories/request-access)
+- Your agent skill report: file://$REPORT_DIR/report.html
+- Want to automate self improvement for your workflows? Request access to Warp Factories: warp.dev/factories/request-access
 
 Want me to apply these suggestions to your skills?

--- a/.agents/skills/skill-doctor/scripts/render_report.py
+++ b/.agents/skills/skill-doctor/scripts/render_report.py
@@ -15,6 +15,7 @@ import html
 import json
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 GRADES = [
@@ -41,6 +42,28 @@ def grade_for(score: float) -> str:
 
 def pct(score) -> int:
     return round(float(score) * 100)
+
+
+def format_generated_at(value) -> str:
+    if not value:
+        return ""
+    raw = str(value)
+    normalized = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+    if re.search(r"[+-]\d{2}$", normalized):
+        normalized += ":00"
+    try:
+        generated_at = datetime.fromisoformat(normalized)
+    except ValueError:
+        return raw
+    suffix = ""
+    if generated_at.tzinfo is not None:
+        generated_at = generated_at.astimezone(timezone.utc)
+        suffix = " UTC"
+    time = generated_at.strftime("%I:%M %p").lstrip("0")
+    return (
+        f"{generated_at.strftime('%B')} {generated_at.day}, "
+        f"{generated_at.year} at {time}{suffix}"
+    )
 
 
 def esc(v) -> str:
@@ -90,12 +113,12 @@ WARP_MARK = (
 )
 
 # Sticky report footer.
-STAMP_NAME = "Self improve your workflows with Warp Factories"
+STAMP_NAME = "Automatically improve your skills with Warp Factories"
 STAMP_SUB = "continuous scoring \u00b7 continuous skill tuning"
 
 # Attribution shown only in the exported share image.
 SHARE_STAMP_NAME = "Get your report with /skill-doctor"
-SHARE_STAMP_SUB = "npx skills add warpdotdev/common-skills --skill skill-doctor"
+SHARE_STAMP_SUB = "warp.dev/skill-doctor"
 
 # Design tokens lifted from warp.dev/factories (factories-landing.css):
 # white ground with a dot grid, Matter-Mono-ish monospace, #2a1eff accent,
@@ -159,7 +182,9 @@ li { margin-bottom: 10px; }
 .bar-name { text-transform: lowercase; }
 .bar-val { font-weight: 600; font-variant-numeric: tabular-nums; }
 .bar-track { height: 8px; background: var(--line-soft); box-shadow: inset 0 0 0 1px var(--line); }
-.bar-fill { height: 100%; background: var(--accent); }
+.bar-fill { height: 100%; background: var(--accent);
+  animation: skill-doctor-fill 700ms cubic-bezier(0.22, 1, 0.36, 1) var(--metric-delay) both;
+  transform-origin: left; }
 .stats { display: grid; grid-template-columns: repeat(3, 1fr); border: 1px solid var(--line);
   border-top: none; background: var(--bg-panel); }
 .stat { padding: 16px 24px 14px; border-left: 1px solid var(--line); }
@@ -181,6 +206,13 @@ li { margin-bottom: 10px; }
   text-transform: uppercase; color: var(--accent); background: var(--surface);
   border: 1px solid var(--line); padding: 5px 10px; margin-top: 6px; cursor: pointer; }
 .diff-toggle:hover { border-color: var(--accent); }
+@keyframes skill-doctor-fill {
+  from { transform: scaleX(0); }
+  to { transform: scaleX(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .bar-fill { animation: none; }
+}
 """
 
 
@@ -188,16 +220,18 @@ def render_page(r) -> str:
     scores = r["scores"]
     stats = r.get("stats", {})
     grade = r.get("grade") or grade_for(scores["overall"])
+    generated_at = format_generated_at(r.get("generated_at"))
 
     bars = "".join(
         f'<div class="bar-row"><div class="bar-head"><span class="bar-name">{esc(name)}</span>'
         f'<span class="bar-val">{pct(val)}</span></div>'
-        f'<div class="bar-track"><div class="bar-fill" style="width:{pct(val)}%"></div></div></div>'
-        for name, val in [
+        f'<div class="bar-track"><div class="bar-fill" '
+        f'style="width:{pct(val)}%;--metric-delay:{180 + index * 110}ms"></div></div></div>'
+        for index, (name, val) in enumerate([
             ("Efficiency", scores.get("efficiency", 0)),
             ("Code Quality", scores.get("code_quality", 0)),
             ("Skill Coverage", scores.get("skill_coverage", 0)),
-        ]
+        ])
     )
     stat_cells = "".join(
         f'<div class="stat"><div class="num">{esc(value)}</div><div class="lbl">{esc(label)}</div></div>'
@@ -248,7 +282,7 @@ def render_page(r) -> str:
   <h1>{esc(r.get('title', 'Agent Skill Report'))}</h1>
   <button class="cta-button" id="share-png" type="button">Share</button>
 </div>
-<p class="muted">Generated {esc(r.get('generated_at', ''))} &middot; harness: {esc(r.get('harness', 'codex'))} &middot; all analysis ran locally</p>
+<p class="muted">Generated {esc(generated_at)} &middot; harness: {esc(r.get('harness', 'codex'))}</p>
 <div class="scorecard">
   <div class="grade-col"><div class="grade">{esc(grade)}</div>
     <div class="grade-label">overall {pct(scores['overall'])}</div></div>
@@ -262,7 +296,7 @@ def render_page(r) -> str:
     <div class="stamp-name">{esc(STAMP_NAME)}</div>
     <div class="stamp-sub">{esc(STAMP_SUB)}</div>
   </div></div>
-  <a class="cta-button" href="{esc(r.get('cta_url', 'https://warp.dev/factories/request-access'))}">Request access to Warp Factories</a>
+  <a class="cta-button" href="{esc(r.get('cta_url', 'https://warp.dev/factories/request-access'))}">Request access</a>
 </div>
 <script>{embedded_diffs_script()}</script>
 <script>{page_script(card_data)}</script>

--- a/.agents/skills/skill-doctor/scripts/render_report.py
+++ b/.agents/skills/skill-doctor/scripts/render_report.py
@@ -10,11 +10,13 @@ Python 3.9+, stdlib only. Uses system fonts so the page and the exported PNG
 render the same everywhere.
 """
 
+import argparse
 import base64
 import html
 import json
 import re
 import sys
+import webbrowser
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -64,6 +66,13 @@ def format_generated_at(value) -> str:
         f"{generated_at.strftime('%B')} {generated_at.day}, "
         f"{generated_at.year} at {time}{suffix}"
     )
+
+
+def open_report(report_path: Path) -> bool:
+    try:
+        return bool(webbrowser.open(report_path.absolute().as_uri(), new=2))
+    except (OSError, webbrowser.Error):
+        return False
 
 
 def esc(v) -> str:
@@ -531,10 +540,26 @@ def page_script(card_data: str) -> str:
     return script.replace("__CARD__", card_data.replace("</", "<\\/")).replace("__CLAMP__", str(DIFF_CLAMP_PX))
 
 
-def main():
-    report_path = Path(
-        sys.argv[1] if len(sys.argv) > 1 else "./skill-doctor-report/report.json"
-    ).expanduser()
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "report_path",
+        nargs="?",
+        default="./skill-doctor-report/report.json",
+        help="Path to the report.json file",
+    )
+    parser.add_argument(
+        "--open",
+        action="store_true",
+        dest="open_browser",
+        help="Open the generated report in the default browser",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    report_path = Path(args.report_path).expanduser()
     if not report_path.exists():
         print(f"error: {report_path} not found", file=sys.stderr)
         sys.exit(1)
@@ -543,8 +568,16 @@ def main():
 
     out_path = report_path.parent / "report.html"
     out_path.write_text(render_page(r))
-    print(f"report: {out_path}")
-    print('        open it and hit "share as png" for a 1200x675 share image')
+    print(f"report: {out_path.absolute().as_uri()}")
+    if args.open_browser:
+        if open_report(out_path):
+            print("        opened in the default browser")
+        else:
+            print(
+                "warning: could not open the report in the default browser",
+                file=sys.stderr,
+            )
+    print('        use "share as png" for a 1200x675 share image')
 
 
 if __name__ == "__main__":

--- a/.agents/skills/skill-doctor/scripts/render_report.py
+++ b/.agents/skills/skill-doctor/scripts/render_report.py
@@ -17,12 +17,6 @@ import re
 import sys
 from pathlib import Path
 
-GRADES = [
-    (0.97, "A+"), (0.93, "A"), (0.90, "A-"),
-    (0.87, "B+"), (0.83, "B"), (0.80, "B-"),
-    (0.77, "C+"), (0.73, "C"), (0.70, "C-"),
-    (0.60, "D"), (0.0, "F"),
-]
 
 DIFFS_BUNDLE_PATH = (
     Path(__file__).resolve().parent.parent / "assets" / "pierre-diffs.js"
@@ -32,15 +26,60 @@ DIFFS_BUNDLE_PATH = (
 DIFF_CLAMP_PX = 320
 
 
-def grade_for(score: float) -> str:
-    for threshold, letter in GRADES:
-        if score >= threshold:
-            return letter
-    return "F"
-
 
 def pct(score) -> int:
     return round(float(score) * 100)
+
+
+def score_label(score) -> str:
+    """Format an aggregate score as a percentage or an inapplicable result."""
+    return "N/A" if score is None else f"{pct(score)}%"
+
+
+def score_counts(report, category):
+    counts = report.get("score_counts", {}).get(category, {})
+    passes = counts.get("passes")
+    fails = counts.get("fails")
+    if (
+        not isinstance(passes, int)
+        or not isinstance(fails, int)
+        or passes < 0
+        or fails < 0
+    ):
+        return None
+    return passes, fails
+
+
+def category_score(report, category):
+    counts = score_counts(report, category)
+    if counts is None:
+        return report["scores"].get(category)
+
+    passes, fails = counts
+    total = passes + fails
+    return passes / total if total else None
+
+
+def overall_score_and_counts(report):
+    efficiency_counts = score_counts(report, "efficiency")
+    code_quality_counts = score_counts(report, "code_quality")
+    if efficiency_counts is not None and code_quality_counts is not None:
+        passes = efficiency_counts[0] + code_quality_counts[0]
+        fails = efficiency_counts[1] + code_quality_counts[1]
+        total = passes + fails
+        if total:
+            return passes / total, (passes, fails)
+
+    return report["scores"]["overall"], score_counts(report, "overall")
+
+
+def overall_count_label(counts) -> str:
+    if counts is None:
+        return "overall pass rate"
+    passes, fails = counts
+    pass_word = "pass" if passes == 1 else "passes"
+    fail_word = "fail" if fails == 1 else "fails"
+    return f"{passes} {pass_word} · {fails} {fail_word}"
 
 
 def esc(v) -> str:
@@ -152,7 +191,7 @@ li { margin-bottom: 10px; }
 .scorecard { display: flex; align-items: center; gap: 48px; border: 1px solid var(--line);
   background: var(--surface); padding: 26px 28px; margin-top: 20px; }
 .grade-col { text-align: center; flex: none; width: 170px; }
-.grade { font-size: 96px; font-weight: 600; line-height: 1; letter-spacing: -5px; color: var(--accent); }
+.grade { font-size: 58px; font-weight: 600; line-height: 1; letter-spacing: -3px; color: var(--accent); }
 .grade-label { font-size: 11px; color: var(--muted-2); margin-top: 8px; text-transform: uppercase; letter-spacing: 0.14em; }
 .bars { flex: 1; display: flex; flex-direction: column; gap: 20px; min-width: 0; }
 .bar-head { display: flex; justify-content: space-between; font-size: 13px; margin-bottom: 7px; font-weight: 500; }
@@ -187,15 +226,19 @@ li { margin-bottom: 10px; }
 def render_page(r) -> str:
     scores = r["scores"]
     stats = r.get("stats", {})
-    grade = r.get("grade") or grade_for(scores["overall"])
+    overall_score, overall_counts = overall_score_and_counts(r)
+    grade = score_label(overall_score)
+    grade_label = overall_count_label(overall_counts)
+    efficiency_score = category_score(r, "efficiency")
+    code_quality_score = category_score(r, "code_quality")
 
     bars = "".join(
         f'<div class="bar-row"><div class="bar-head"><span class="bar-name">{esc(name)}</span>'
-        f'<span class="bar-val">{pct(val)}</span></div>'
-        f'<div class="bar-track"><div class="bar-fill" style="width:{pct(val)}%"></div></div></div>'
+        f'<span class="bar-val">{score_label(val)}</span></div>'
+        f'<div class="bar-track"><div class="bar-fill" style="width:{pct(val) if val is not None else 0}%"></div></div></div>'
         for name, val in [
-            ("Efficiency", scores.get("efficiency", 0)),
-            ("Code Quality", scores.get("code_quality", 0)),
+            ("Efficiency", efficiency_score),
+            ("Code Quality", code_quality_score),
             ("Skill Coverage", scores.get("skill_coverage", 0)),
         ]
     )
@@ -221,10 +264,18 @@ def render_page(r) -> str:
         "handle": r.get("handle") or "agent skill report",
         "harness": r.get("harness", "codex"),
         "grade": grade,
-        "grade_label": f"overall {pct(scores['overall'])}",
+        "grade_label": grade_label,
         "bars": [
-            ["Efficiency", pct(scores.get("efficiency", 0))],
-            ["Code Quality", pct(scores.get("code_quality", 0))],
+            [
+                "Efficiency",
+                pct(efficiency_score) if efficiency_score is not None else None,
+            ],
+            [
+                "Code Quality",
+                pct(code_quality_score)
+                if code_quality_score is not None
+                else None,
+            ],
             ["Skill Coverage", pct(scores.get("skill_coverage", 0))],
         ],
         "meta": f"{stats.get('sessions_scanned', 0)} conversations found \u00b7 "
@@ -251,7 +302,7 @@ def render_page(r) -> str:
 <p class="muted">Generated {esc(r.get('generated_at', ''))} &middot; harness: {esc(r.get('harness', 'codex'))} &middot; all analysis ran locally</p>
 <div class="scorecard">
   <div class="grade-col"><div class="grade">{esc(grade)}</div>
-    <div class="grade-label">overall {pct(scores['overall'])}</div></div>
+    <div class="grade-label">{esc(grade_label)}</div></div>
   <div class="bars">{bars}</div>
 </div>
 <div class="stats">{stat_cells}</div>
@@ -403,7 +454,7 @@ def page_script(card_data: str) -> str:
 
     var mainMid = barBottom + 74 + (405 - 74) / 2;
 
-    font('600', 170);
+    font('600', 150);
     track('-8px');
     c.fillStyle = ACCENT;
     text(CARD.grade, fx + 186, mainMid - 15, 'center');
@@ -424,13 +475,15 @@ def page_script(card_data: str) -> str:
       c.fillStyle = FG;
       text(bar[0].toLowerCase(), bx, y + 9);
       font('600', 14);
-      text(String(bar[1]), bx + bw, y + 9, 'right');
+      text(bar[1] === null ? 'N/A' : String(bar[1]) + '%', bx + bw, y + 9, 'right');
       c.fillStyle = LINE_SOFT;
       c.fillRect(bx, y + 27, bw, 8);
       c.strokeStyle = LINE;
       c.strokeRect(bx + 0.5, y + 27.5, bw - 1, 7);
-      c.fillStyle = ACCENT;
-      c.fillRect(bx, y + 27, bw * Math.max(0, Math.min(100, bar[1])) / 100, 8);
+      if (bar[1] !== null) {
+        c.fillStyle = ACCENT;
+        c.fillRect(bx, y + 27, bw * Math.max(0, Math.min(100, bar[1])) / 100, 8);
+      }
     });
 
     // stats
@@ -505,7 +558,6 @@ def main():
         print(f"error: {report_path} not found", file=sys.stderr)
         sys.exit(1)
     r = json.loads(report_path.read_text())
-    r.setdefault("grade", grade_for(r["scores"]["overall"]))
 
     out_path = report_path.parent / "report.html"
     out_path.write_text(render_page(r))

--- a/.agents/skills/skill-doctor/scripts/render_report.py
+++ b/.agents/skills/skill-doctor/scripts/render_report.py
@@ -17,6 +17,12 @@ import re
 import sys
 from pathlib import Path
 
+GRADES = [
+    (0.97, "A+"), (0.93, "A"), (0.90, "A-"),
+    (0.87, "B+"), (0.83, "B"), (0.80, "B-"),
+    (0.77, "C+"), (0.73, "C"), (0.70, "C-"),
+    (0.60, "D"), (0.0, "F"),
+]
 
 DIFFS_BUNDLE_PATH = (
     Path(__file__).resolve().parent.parent / "assets" / "pierre-diffs.js"
@@ -26,60 +32,15 @@ DIFFS_BUNDLE_PATH = (
 DIFF_CLAMP_PX = 320
 
 
+def grade_for(score: float) -> str:
+    for threshold, letter in GRADES:
+        if score >= threshold:
+            return letter
+    return "F"
+
 
 def pct(score) -> int:
     return round(float(score) * 100)
-
-
-def score_label(score) -> str:
-    """Format an aggregate score as a percentage or an inapplicable result."""
-    return "N/A" if score is None else f"{pct(score)}%"
-
-
-def score_counts(report, category):
-    counts = report.get("score_counts", {}).get(category, {})
-    passes = counts.get("passes")
-    fails = counts.get("fails")
-    if (
-        not isinstance(passes, int)
-        or not isinstance(fails, int)
-        or passes < 0
-        or fails < 0
-    ):
-        return None
-    return passes, fails
-
-
-def category_score(report, category):
-    counts = score_counts(report, category)
-    if counts is None:
-        return report["scores"].get(category)
-
-    passes, fails = counts
-    total = passes + fails
-    return passes / total if total else None
-
-
-def overall_score_and_counts(report):
-    efficiency_counts = score_counts(report, "efficiency")
-    code_quality_counts = score_counts(report, "code_quality")
-    if efficiency_counts is not None and code_quality_counts is not None:
-        passes = efficiency_counts[0] + code_quality_counts[0]
-        fails = efficiency_counts[1] + code_quality_counts[1]
-        total = passes + fails
-        if total:
-            return passes / total, (passes, fails)
-
-    return report["scores"]["overall"], score_counts(report, "overall")
-
-
-def overall_count_label(counts) -> str:
-    if counts is None:
-        return "overall pass rate"
-    passes, fails = counts
-    pass_word = "pass" if passes == 1 else "passes"
-    fail_word = "fail" if fails == 1 else "fails"
-    return f"{passes} {pass_word} · {fails} {fail_word}"
 
 
 def esc(v) -> str:
@@ -191,7 +152,7 @@ li { margin-bottom: 10px; }
 .scorecard { display: flex; align-items: center; gap: 48px; border: 1px solid var(--line);
   background: var(--surface); padding: 26px 28px; margin-top: 20px; }
 .grade-col { text-align: center; flex: none; width: 170px; }
-.grade { font-size: 58px; font-weight: 600; line-height: 1; letter-spacing: -3px; color: var(--accent); }
+.grade { font-size: 96px; font-weight: 600; line-height: 1; letter-spacing: -5px; color: var(--accent); }
 .grade-label { font-size: 11px; color: var(--muted-2); margin-top: 8px; text-transform: uppercase; letter-spacing: 0.14em; }
 .bars { flex: 1; display: flex; flex-direction: column; gap: 20px; min-width: 0; }
 .bar-head { display: flex; justify-content: space-between; font-size: 13px; margin-bottom: 7px; font-weight: 500; }
@@ -226,19 +187,15 @@ li { margin-bottom: 10px; }
 def render_page(r) -> str:
     scores = r["scores"]
     stats = r.get("stats", {})
-    overall_score, overall_counts = overall_score_and_counts(r)
-    grade = score_label(overall_score)
-    grade_label = overall_count_label(overall_counts)
-    efficiency_score = category_score(r, "efficiency")
-    code_quality_score = category_score(r, "code_quality")
+    grade = r.get("grade") or grade_for(scores["overall"])
 
     bars = "".join(
         f'<div class="bar-row"><div class="bar-head"><span class="bar-name">{esc(name)}</span>'
-        f'<span class="bar-val">{score_label(val)}</span></div>'
-        f'<div class="bar-track"><div class="bar-fill" style="width:{pct(val) if val is not None else 0}%"></div></div></div>'
+        f'<span class="bar-val">{pct(val)}</span></div>'
+        f'<div class="bar-track"><div class="bar-fill" style="width:{pct(val)}%"></div></div></div>'
         for name, val in [
-            ("Efficiency", efficiency_score),
-            ("Code Quality", code_quality_score),
+            ("Efficiency", scores.get("efficiency", 0)),
+            ("Code Quality", scores.get("code_quality", 0)),
             ("Skill Coverage", scores.get("skill_coverage", 0)),
         ]
     )
@@ -264,18 +221,10 @@ def render_page(r) -> str:
         "handle": r.get("handle") or "agent skill report",
         "harness": r.get("harness", "codex"),
         "grade": grade,
-        "grade_label": grade_label,
+        "grade_label": f"overall {pct(scores['overall'])}",
         "bars": [
-            [
-                "Efficiency",
-                pct(efficiency_score) if efficiency_score is not None else None,
-            ],
-            [
-                "Code Quality",
-                pct(code_quality_score)
-                if code_quality_score is not None
-                else None,
-            ],
+            ["Efficiency", pct(scores.get("efficiency", 0))],
+            ["Code Quality", pct(scores.get("code_quality", 0))],
             ["Skill Coverage", pct(scores.get("skill_coverage", 0))],
         ],
         "meta": f"{stats.get('sessions_scanned', 0)} conversations found \u00b7 "
@@ -302,7 +251,7 @@ def render_page(r) -> str:
 <p class="muted">Generated {esc(r.get('generated_at', ''))} &middot; harness: {esc(r.get('harness', 'codex'))} &middot; all analysis ran locally</p>
 <div class="scorecard">
   <div class="grade-col"><div class="grade">{esc(grade)}</div>
-    <div class="grade-label">{esc(grade_label)}</div></div>
+    <div class="grade-label">overall {pct(scores['overall'])}</div></div>
   <div class="bars">{bars}</div>
 </div>
 <div class="stats">{stat_cells}</div>
@@ -454,7 +403,7 @@ def page_script(card_data: str) -> str:
 
     var mainMid = barBottom + 74 + (405 - 74) / 2;
 
-    font('600', 150);
+    font('600', 170);
     track('-8px');
     c.fillStyle = ACCENT;
     text(CARD.grade, fx + 186, mainMid - 15, 'center');
@@ -475,15 +424,13 @@ def page_script(card_data: str) -> str:
       c.fillStyle = FG;
       text(bar[0].toLowerCase(), bx, y + 9);
       font('600', 14);
-      text(bar[1] === null ? 'N/A' : String(bar[1]) + '%', bx + bw, y + 9, 'right');
+      text(String(bar[1]), bx + bw, y + 9, 'right');
       c.fillStyle = LINE_SOFT;
       c.fillRect(bx, y + 27, bw, 8);
       c.strokeStyle = LINE;
       c.strokeRect(bx + 0.5, y + 27.5, bw - 1, 7);
-      if (bar[1] !== null) {
-        c.fillStyle = ACCENT;
-        c.fillRect(bx, y + 27, bw * Math.max(0, Math.min(100, bar[1])) / 100, 8);
-      }
+      c.fillStyle = ACCENT;
+      c.fillRect(bx, y + 27, bw * Math.max(0, Math.min(100, bar[1])) / 100, 8);
     });
 
     // stats
@@ -558,6 +505,7 @@ def main():
         print(f"error: {report_path} not found", file=sys.stderr)
         sys.exit(1)
     r = json.loads(report_path.read_text())
+    r.setdefault("grade", grade_for(r["scores"]["overall"]))
 
     out_path = report_path.parent / "report.html"
     out_path.write_text(render_page(r))

--- a/.agents/skills/skill-doctor/scripts/test_render_report.py
+++ b/.agents/skills/skill-doctor/scripts/test_render_report.py
@@ -48,12 +48,6 @@ class ReportRendererTests(unittest.TestCase):
         self.assertIn("| Warp | `warp` |", harness_text)
         self.assertIn("| Claude Code | `claude` |", harness_text)
         self.assertIn("| Codex | `codex` |", harness_text)
-        self.assertIn(
-            "Skill discovery and conversation collection are separate "
-            "compatibility layers",
-            harness_text,
-        )
-        self.assertIn("~/.gemini/tmp/<project-id>/chats/", harness_text)
         self.assertIn("stop before creating a report directory", harness_text)
 
     def test_code_diffs_follow_os_theme(self):

--- a/.agents/skills/skill-doctor/scripts/test_render_report.py
+++ b/.agents/skills/skill-doctor/scripts/test_render_report.py
@@ -4,7 +4,7 @@
 import unittest
 from pathlib import Path
 
-from render_report import embedded_diffs_script, render_page
+from render_report import embedded_diffs_script, format_generated_at, render_page
 
 
 class ReportRendererTests(unittest.TestCase):
@@ -108,11 +108,23 @@ class ReportRendererTests(unittest.TestCase):
         self.assertNotIn("Do this automatically with Warp Factories", page)
         self.assertIn('<div class="stamp-row row factories-footer">', page)
         self.assertIn(
-            '<div class="stamp-name">Self improve your workflows with Warp Factories</div>',
+            '<div class="stamp-name">Automatically improve your skills with Warp Factories</div>',
             page,
         )
-        self.assertIn(">Request access to Warp Factories</a>", page)
+        self.assertIn(">Request access</a>", page)
         self.assertIn(".factories-footer { position: sticky; bottom: 16px;", page)
+        self.assertNotIn("all analysis ran locally", page)
+        self.assertIn(
+            "Generated August 25, 2026 at 12:00 AM UTC &middot; harness: codex",
+            page,
+        )
+
+    def test_generated_timestamp_formatting(self):
+        self.assertEqual(
+            format_generated_at("2026-08-27T22:06:10.421941+00"),
+            "August 27, 2026 at 10:06 PM UTC",
+        )
+        self.assertEqual(format_generated_at("not-a-date"), "not-a-date")
 
     def test_share_card_uses_skill_doctor_attribution(self):
         page = render_page({
@@ -126,11 +138,35 @@ class ReportRendererTests(unittest.TestCase):
 
         self.assertIn(
             '"stamp": ["Get your report with /skill-doctor", '
-            '"npx skills add warpdotdev/common-skills --skill skill-doctor"]',
+            '"warp.dev/skill-doctor"]',
             page,
         )
         self.assertIn('"eyebrow": "skill-doctor"', page)
         self.assertIn("text('# ' + CARD.eyebrow", page)
+
+    def test_report_metric_lines_animate_like_skill_doctor_landing_page(self):
+        page = render_page({
+            "scores": {
+                "efficiency": 0.75,
+                "code_quality": 0.93,
+                "skill_coverage": 0.74,
+                "overall": 0.82,
+            },
+        })
+
+        self.assertIn(
+            "animation: skill-doctor-fill 700ms "
+            "cubic-bezier(0.22, 1, 0.36, 1) var(--metric-delay) both",
+            page,
+        )
+        self.assertIn("@keyframes skill-doctor-fill", page)
+        self.assertIn("from { transform: scaleX(0); }", page)
+        self.assertIn("to { transform: scaleX(1); }", page)
+        self.assertIn("width:75%;--metric-delay:180ms", page)
+        self.assertIn("width:93%;--metric-delay:290ms", page)
+        self.assertIn("width:74%;--metric-delay:400ms", page)
+        self.assertIn("@media (prefers-reduced-motion: reduce)", page)
+        self.assertIn(".bar-fill { animation: none; }", page)
 
     def test_skill_output_uses_report_and_warp_factories_labels(self):
         skill_path = Path(__file__).resolve().parent.parent / "SKILL.md"

--- a/.agents/skills/skill-doctor/scripts/test_render_report.py
+++ b/.agents/skills/skill-doctor/scripts/test_render_report.py
@@ -142,6 +142,15 @@ class ReportRendererTests(unittest.TestCase):
             "and a grade of 80%",
             skill_text,
         )
+        self.assertIn(
+            "Use only `failed_conversations` as evidence for "
+            "skill-improvement suggestions and draft skill edits",
+            skill_text,
+        )
+        self.assertIn(
+            "An `insufficient_evidence` result does not make a conversation fail",
+            skill_text,
+        )
         self.assertNotIn("mean of efficiency scores", skill_text)
         self.assertNotIn("mean of code-quality scores", skill_text)
 

--- a/.agents/skills/skill-doctor/scripts/test_render_report.py
+++ b/.agents/skills/skill-doctor/scripts/test_render_report.py
@@ -3,8 +3,15 @@
 
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
-from render_report import embedded_diffs_script, format_generated_at, render_page
+from render_report import (
+    embedded_diffs_script,
+    format_generated_at,
+    open_report,
+    parse_args,
+    render_page,
+)
 
 
 class ReportRendererTests(unittest.TestCase):
@@ -126,6 +133,24 @@ class ReportRendererTests(unittest.TestCase):
         )
         self.assertEqual(format_generated_at("not-a-date"), "not-a-date")
 
+    def test_open_report_uses_default_browser_with_file_uri(self):
+        report_path = Path("/tmp/skill doctor/report.html")
+        args = parse_args([str(report_path), "--open"])
+
+        self.assertEqual(args.report_path, str(report_path))
+        self.assertTrue(args.open_browser)
+
+        with patch("render_report.webbrowser.open", return_value=True) as browser_open:
+            self.assertTrue(open_report(report_path))
+
+        browser_open.assert_called_once_with(
+            report_path.absolute().as_uri(),
+            new=2,
+        )
+
+        with patch("render_report.webbrowser.open", side_effect=OSError):
+            self.assertFalse(open_report(report_path))
+
     def test_share_card_uses_skill_doctor_attribution(self):
         page = render_page({
             "scores": {
@@ -173,14 +198,20 @@ class ReportRendererTests(unittest.TestCase):
         skill_text = skill_path.read_text()
 
         self.assertIn(
-            "- Your agent skill report: [View in browser]",
+            'render_report.py" "$REPORT_DIR/report.json" --open',
+            skill_text,
+        )
+        self.assertIn(
+            "- Your agent skill report: file://$REPORT_DIR/report.html",
             skill_text,
         )
         self.assertIn(
             "- Want to automate self improvement for your workflows? "
-            "[Request access to Warp Factories]",
+            "Request access to Warp Factories: "
+            "warp.dev/factories/request-access",
             skill_text,
         )
+        self.assertNotIn("[View in browser]", skill_text)
 
     def test_skill_edits_only_use_failed_conversations(self):
         skill_path = Path(__file__).resolve().parent.parent / "SKILL.md"
@@ -195,11 +226,6 @@ class ReportRendererTests(unittest.TestCase):
             skill_text,
         )
         self.assertIn(
-            "raw scores of `1.0`, `0.8`, `0.4`, and `0.2` to report scores "
-            "of `1.0`, `0.9`, `0.7`, and `0.6`",
-            skill_text,
-        )
-        self.assertIn(
             "`overall = 0.5 * efficiency + 0.35 * code_quality + "
             "0.15 * skill_coverage.`",
             skill_text,
@@ -211,10 +237,6 @@ class ReportRendererTests(unittest.TestCase):
         self.assertIn(
             "Use only `failed_conversations` as evidence for "
             "skill-improvement suggestions and draft skill edits",
-            skill_text,
-        )
-        self.assertIn(
-            "Every proposed skill patch must follow STE-100",
             skill_text,
         )
 

--- a/.agents/skills/skill-doctor/scripts/test_render_report.py
+++ b/.agents/skills/skill-doctor/scripts/test_render_report.py
@@ -79,6 +79,72 @@ class ReportRendererTests(unittest.TestCase):
         self.assertIn("--diffs-font-family: var(--mono-font)", page)
         self.assertIn("--diffs-header-font-family: var(--mono-font)", page)
 
+    def test_report_renders_overall_pass_rate_and_counts(self):
+        page = render_page({
+            "scores": {
+                "efficiency": 0.1,
+                "code_quality": 0.1,
+                "skill_coverage": 0.5,
+                "overall": 0.1,
+            },
+            "score_counts": {
+                "efficiency": {"passes": 3, "fails": 1},
+                "code_quality": {"passes": 1, "fails": 0},
+                "overall": {"passes": 4, "fails": 1},
+            },
+        })
+
+        self.assertIn('<div class="grade">80%</div>', page)
+        self.assertIn('<div class="grade-label">4 passes · 1 fail</div>', page)
+        self.assertIn('<span class="bar-val">75%</span>', page)
+        self.assertIn('<span class="bar-val">100%</span>', page)
+
+    def test_report_renders_missing_code_quality_as_not_applicable(self):
+        page = render_page({
+            "scores": {
+                "efficiency": 1.0,
+                "code_quality": None,
+                "skill_coverage": 0.0,
+                "overall": 1.0,
+            },
+            "score_counts": {
+                "efficiency": {"passes": 1, "fails": 0},
+                "code_quality": {"passes": 0, "fails": 0},
+                "overall": {"passes": 1, "fails": 0},
+            },
+        })
+
+        self.assertIn('<span class="bar-val">N/A</span>', page)
+        self.assertIn('["Code Quality", null]', page)
+        self.assertIn(
+            '<div class="grade-label">1 pass · 0 fails</div>',
+            page,
+        )
+
+    def test_skill_uses_thresholded_pass_rate_aggregation(self):
+        skill_path = Path(__file__).resolve().parent.parent / "SKILL.md"
+        skill_text = skill_path.read_text()
+
+        self.assertIn(
+            "An efficiency result passes when its numeric score is at least `0.5`",
+            skill_text,
+        )
+        self.assertIn(
+            "A code-quality result passes when its numeric score is at least `0.5`",
+            skill_text,
+        )
+        self.assertIn(
+            "Skill coverage is diagnostic and does not affect the grade",
+            skill_text,
+        )
+        self.assertIn(
+            "four passes and one fail produces an `overall` score of `0.8` "
+            "and a grade of 80%",
+            skill_text,
+        )
+        self.assertNotIn("mean of efficiency scores", skill_text)
+        self.assertNotIn("mean of code-quality scores", skill_text)
+
     def test_factories_footer_is_sticky_and_contains_inline_cta(self):
         report = {
             "title": "Agent Skill Report",

--- a/.agents/skills/skill-doctor/scripts/test_render_report.py
+++ b/.agents/skills/skill-doctor/scripts/test_render_report.py
@@ -213,6 +213,10 @@ class ReportRendererTests(unittest.TestCase):
             "skill-improvement suggestions and draft skill edits",
             skill_text,
         )
+        self.assertIn(
+            "Every proposed skill patch must follow STE-100",
+            skill_text,
+        )
 
     def test_report_renders_letter_grade(self):
         page = render_page({

--- a/.agents/skills/skill-doctor/scripts/test_render_report.py
+++ b/.agents/skills/skill-doctor/scripts/test_render_report.py
@@ -151,7 +151,16 @@ class ReportRendererTests(unittest.TestCase):
         skill_text = skill_path.read_text()
 
         self.assertIn(
-            "`efficiency` = mean of efficiency scores across all scored sessions",
+            "`raw_efficiency` = mean of efficiency scores across all scored sessions",
+            skill_text,
+        )
+        self.assertIn(
+            "`curve(score) = 0.5 + 0.5 * score`",
+            skill_text,
+        )
+        self.assertIn(
+            "raw scores of `1.0`, `0.8`, `0.4`, and `0.2` to report scores "
+            "of `1.0`, `0.9`, `0.7`, and `0.6`",
             skill_text,
         )
         self.assertIn(
@@ -160,8 +169,7 @@ class ReportRendererTests(unittest.TestCase):
             skill_text,
         )
         self.assertIn(
-            "with at least one applicable efficiency or code-quality score "
-            "below `0.5`",
+            "from each conversation's raw, uncurved scorer results",
             skill_text,
         )
         self.assertIn(
@@ -173,15 +181,15 @@ class ReportRendererTests(unittest.TestCase):
     def test_report_renders_letter_grade(self):
         page = render_page({
             "scores": {
-                "efficiency": 0.8,
-                "code_quality": 0.8,
+                "efficiency": 0.7,
+                "code_quality": 0.7,
                 "skill_coverage": 0.8,
-                "overall": 0.8,
+                "overall": 0.7,
             },
         })
 
-        self.assertIn('<div class="grade">B-</div>', page)
-        self.assertIn('<div class="grade-label">overall 80</div>', page)
+        self.assertIn('<div class="grade">C-</div>', page)
+        self.assertIn('<div class="grade-label">overall 70</div>', page)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/skill-doctor/scripts/test_render_report.py
+++ b/.agents/skills/skill-doctor/scripts/test_render_report.py
@@ -79,81 +79,6 @@ class ReportRendererTests(unittest.TestCase):
         self.assertIn("--diffs-font-family: var(--mono-font)", page)
         self.assertIn("--diffs-header-font-family: var(--mono-font)", page)
 
-    def test_report_renders_overall_pass_rate_and_counts(self):
-        page = render_page({
-            "scores": {
-                "efficiency": 0.1,
-                "code_quality": 0.1,
-                "skill_coverage": 0.5,
-                "overall": 0.1,
-            },
-            "score_counts": {
-                "efficiency": {"passes": 3, "fails": 1},
-                "code_quality": {"passes": 1, "fails": 0},
-                "overall": {"passes": 4, "fails": 1},
-            },
-        })
-
-        self.assertIn('<div class="grade">80%</div>', page)
-        self.assertIn('<div class="grade-label">4 passes · 1 fail</div>', page)
-        self.assertIn('<span class="bar-val">75%</span>', page)
-        self.assertIn('<span class="bar-val">100%</span>', page)
-
-    def test_report_renders_missing_code_quality_as_not_applicable(self):
-        page = render_page({
-            "scores": {
-                "efficiency": 1.0,
-                "code_quality": None,
-                "skill_coverage": 0.0,
-                "overall": 1.0,
-            },
-            "score_counts": {
-                "efficiency": {"passes": 1, "fails": 0},
-                "code_quality": {"passes": 0, "fails": 0},
-                "overall": {"passes": 1, "fails": 0},
-            },
-        })
-
-        self.assertIn('<span class="bar-val">N/A</span>', page)
-        self.assertIn('["Code Quality", null]', page)
-        self.assertIn(
-            '<div class="grade-label">1 pass · 0 fails</div>',
-            page,
-        )
-
-    def test_skill_uses_thresholded_pass_rate_aggregation(self):
-        skill_path = Path(__file__).resolve().parent.parent / "SKILL.md"
-        skill_text = skill_path.read_text()
-
-        self.assertIn(
-            "An efficiency result passes when its numeric score is at least `0.5`",
-            skill_text,
-        )
-        self.assertIn(
-            "A code-quality result passes when its numeric score is at least `0.5`",
-            skill_text,
-        )
-        self.assertIn(
-            "Skill coverage is diagnostic and does not affect the grade",
-            skill_text,
-        )
-        self.assertIn(
-            "four passes and one fail produces an `overall` score of `0.8` "
-            "and a grade of 80%",
-            skill_text,
-        )
-        self.assertIn(
-            "Use only `failed_conversations` as evidence for "
-            "skill-improvement suggestions and draft skill edits",
-            skill_text,
-        )
-        self.assertIn(
-            "An `insufficient_evidence` result does not make a conversation fail",
-            skill_text,
-        )
-        self.assertNotIn("mean of efficiency scores", skill_text)
-        self.assertNotIn("mean of code-quality scores", skill_text)
-
     def test_factories_footer_is_sticky_and_contains_inline_cta(self):
         report = {
             "title": "Agent Skill Report",
@@ -220,6 +145,43 @@ class ReportRendererTests(unittest.TestCase):
             "[Request access to Warp Factories]",
             skill_text,
         )
+
+    def test_skill_edits_only_use_failed_conversations(self):
+        skill_path = Path(__file__).resolve().parent.parent / "SKILL.md"
+        skill_text = skill_path.read_text()
+
+        self.assertIn(
+            "`efficiency` = mean of efficiency scores across all scored sessions",
+            skill_text,
+        )
+        self.assertIn(
+            "`overall = 0.5 * efficiency + 0.35 * code_quality + "
+            "0.15 * skill_coverage.`",
+            skill_text,
+        )
+        self.assertIn(
+            "with at least one applicable efficiency or code-quality score "
+            "below `0.5`",
+            skill_text,
+        )
+        self.assertIn(
+            "Use only `failed_conversations` as evidence for "
+            "skill-improvement suggestions and draft skill edits",
+            skill_text,
+        )
+
+    def test_report_renders_letter_grade(self):
+        page = render_page({
+            "scores": {
+                "efficiency": 0.8,
+                "code_quality": 0.8,
+                "skill_coverage": 0.8,
+                "overall": 0.8,
+            },
+        })
+
+        self.assertIn('<div class="grade">B-</div>', page)
+        self.assertIn('<div class="grade-label">overall 80</div>', page)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Skill-doctor now treats qualitative rubric values as raw diagnostic scores rather than literal percentages. It curves their means into the existing letter-grade range for reporting, while raw scores still determine which failed conversations can motivate skill edits.

<img width="2506" height="1754" alt="CleanShot 2026-08-27 at 19 05 46@2x" src="https://github.com/user-attachments/assets/d3e36e89-97a9-409b-81d6-3d12aea1f5f1" />


## What changed

- Curve grades to `0.5 + 0.5 * score`. That way a slight failure is no longer an F; it's a C or a B.
- Format generated timestamps as readable UTC dates.
- Update the Warp Factories heading and shorten its CTA to `Request access`.
- Use `warp.dev/skill-doctor` in exported share-image footers.
- Add a slick bar graph animation on the report.
- I noticed CC and Codex didn't format file links at all. This auto-opens the report in the browser now, with tweaked copy in the bullets to make more sense when hyperlinks aren't supported.

## Validation

- Full skill-doctor suite: 16 of 16 tests passed.
- Animation regression test: passed.
- Browser verification confirmed each metric starts at `scaleX(0)`, follows the expected stagger, and finishes at its scored width.
- `python3 -m py_compile .agents/skills/skill-doctor/scripts/render_report.py .agents/skills/skill-doctor/scripts/test_render_report.py`
- `git diff --check`

Co-Authored-By: Warp <agent@warp.dev>


