### PR TITLE
Opencode support

### DIFF
--- a/.agents/skills/skill-doctor/references/supported-harnesses.md
+++ b/.agents/skills/skill-doctor/references/supported-harnesses.md
@@ -9,12 +9,13 @@ This file is the single source of truth for harness support in `skill-doctor`. R
 | Warp | `warp` | Read-only Warp conversation databases |
 | Claude Code | `claude` | Project-history JSONL |
 | Codex | `codex` | Rollout JSONL |
+| OpenCode | `opencode` | Read-only current-format SQLite history |
 
 At startup, identify the harness executing the skill from the runtime context. Do not infer it from conversation files found on disk.
 
 If the executing harness is not listed above, or cannot be identified confidently, stop before creating a report directory or reading conversation history. Tell the user:
 
-> skill-doctor currently supports Warp, Claude Code, and Codex. This run appears to be using an unsupported harness, so no conversations were read.
+> skill-doctor currently supports Warp, Claude Code, Codex, and OpenCode. This run appears to be using an unsupported harness, so no conversations were read.
 
 ## Collector source selection
 
@@ -27,6 +28,8 @@ Harness-specific source overrides:
 
 - `--claude-home PATH` — nonstandard Claude Code configuration directory.
 - `--codex-home PATH` — nonstandard Codex home.
+- `--opencode-data-dir PATH` — nonstandard OpenCode data root. The default is `$XDG_DATA_HOME/opencode`, or `~/.local/share/opencode` when `XDG_DATA_HOME` is unset.
+- `--opencode-db PATH` — explicit OpenCode database, including an `OPENCODE_DB` path; repeatable and replaces default `opencode.db`/`opencode-*.db` discovery. Relative paths resolve under the OpenCode data root.
 - `--warp-db PATH` — explicit Warp database; repeatable.
 - `--warp-data-dir PATH` — nonstandard Warp channel-data directory.
 

--- a/.agents/skills/skill-doctor/scripts/collect_sessions.py
+++ b/.agents/skills/skill-doctor/scripts/collect_sessions.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Collect local Claude Code, Codex, and Warp sessions and skills for scoring.
+"""Collect local Claude Code, Codex, OpenCode, and Warp sessions and skills for scoring.
 
-Scans Claude Code project history, Codex rollout files, and/or Warp's local
-conversation databases, discovers installed skills, detects which sessions
+Scans Claude Code project history, Codex rollout files, OpenCode databases,
+and/or Warp's local conversation databases, discovers installed skills, detects
+which sessions
 used which skills, and emits:
 
   <out>/inventory.json        - skills, per-session stats, sampling decisions
@@ -25,6 +26,7 @@ from warp_decoder import ProtobufDecodeError, decode_task
 
 MAX_FILE_BYTES = 8 * 1024 * 1024
 MAX_WARP_CONVERSATION_BYTES = 32 * 1024 * 1024
+MAX_OPENCODE_WARNINGS = 10
 MAX_MSG_CHARS = 1500
 MAX_TOOL_CHARS = 500
 MAX_TRANSCRIPT_ENTRIES = 160
@@ -33,13 +35,14 @@ TRANSCRIPT_TAIL = 40
 
 CODE_EDIT_HINTS = ("apply_patch", "*** Begin Patch", "edit_file", "create_file", "str_replace", "write_file")
 CLAUDE_CODE_EDIT_TOOLS = {"Edit", "MultiEdit", "NotebookEdit", "Write"}
+OPENCODE_CODE_EDIT_TOOLS = {"apply_patch", "edit", "patch", "write"}
 
 
 def parse_args():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument(
         "--harness",
-        choices=("auto", "all", "claude", "codex", "warp"),
+        choices=("auto", "all", "claude", "codex", "opencode", "warp"),
         default="auto",
         help="session source (default: auto; scans every locally available source)",
     )
@@ -49,6 +52,16 @@ def parse_args():
         help="Claude Code config directory (default: CLAUDE_CONFIG_DIR or ~/.claude)",
     )
     p.add_argument("--codex-home", default=os.environ.get("CODEX_HOME", "~/.codex"))
+    p.add_argument(
+        "--opencode-db",
+        action="append",
+        default=[],
+        help="explicit OpenCode database path (repeatable; replaces discovery)",
+    )
+    p.add_argument(
+        "--opencode-data-dir",
+        help="OpenCode data root (default: $XDG_DATA_HOME/opencode or ~/.local/share/opencode)",
+    )
     p.add_argument(
         "--warp-db",
         action="append",
@@ -488,6 +501,589 @@ def parse_sqlite_timestamp(value):
     return parsed.astimezone(timezone.utc)
 
 
+def opencode_data_root(value=None):
+    if value:
+        return Path(value).expanduser()
+    xdg_data = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    return xdg_data / "opencode"
+
+
+def opencode_database_identity(path):
+    stat = path.stat()
+    return hashlib.sha1(f"{stat.st_dev}:{stat.st_ino}".encode()).hexdigest()[:12]
+
+
+def discover_opencode_databases(explicit_paths=(), data_dir=None, rejected=None):
+    """Find current OpenCode databases; explicit paths replace discovery."""
+    root = opencode_data_root(data_dir)
+    if explicit_paths:
+        candidates = []
+        for value in explicit_paths:
+            if value == ":memory:":
+                if rejected is not None:
+                    rejected.append((value, "in-memory databases are unsupported"))
+                continue
+            candidate = Path(value).expanduser()
+            candidates.append(
+                candidate if candidate.is_absolute() else root / candidate
+            )
+    else:
+        candidates = [root / "opencode.db"]
+        if root.is_dir():
+            candidates.extend(root.glob("opencode-*.db"))
+
+    databases = []
+    seen = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+            stat = resolved.stat()
+            identity = (stat.st_dev, stat.st_ino)
+        except OSError as exc:
+            if explicit_paths and rejected is not None:
+                rejected.append((str(candidate), exc.strerror or str(exc)))
+            continue
+        if not resolved.is_file():
+            if explicit_paths and rejected is not None:
+                rejected.append((str(candidate), "not a file"))
+            continue
+        if identity in seen:
+            continue
+        seen.add(identity)
+        databases.append(resolved)
+    return sorted(databases)
+
+
+def open_opencode_database(path):
+    connection = sqlite3.connect(f"{path.as_uri()}?mode=ro", uri=True, timeout=2)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA query_only = ON")
+    connection.execute("PRAGMA busy_timeout = 2000")
+    return connection
+
+
+def opencode_database_has_current_schema(connection):
+    tables = {
+        row["name"]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' "
+            "AND name IN ('session', 'message', 'part', 'session_message')"
+        )
+    }
+    if "session" not in tables or not {"id"}.issubset(
+        sqlite_table_columns(connection, "session")
+    ):
+        return False
+    message_parts = (
+        {"message", "part"}.issubset(tables)
+        and {"id", "session_id", "data"}.issubset(
+            sqlite_table_columns(connection, "message")
+        )
+        and {"id", "message_id", "data"}.issubset(
+            sqlite_table_columns(connection, "part")
+        )
+    )
+    session_messages = "session_message" in tables and {
+        "session_id",
+        "type",
+        "seq",
+        "data",
+    }.issubset(sqlite_table_columns(connection, "session_message"))
+    return message_parts or session_messages
+
+
+def opencode_ms(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        return datetime.fromtimestamp(value / 1000, tz=timezone.utc)
+    except (OSError, OverflowError, ValueError):
+        return None
+
+
+def opencode_payload_times(value, inside_time=False):
+    times = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            in_time = inside_time or key == "time"
+            if in_time and key in {"created", "updated", "completed", "ran", "pruned"}:
+                parsed = opencode_ms(child)
+                if parsed:
+                    times.append(parsed)
+            times.extend(opencode_payload_times(child, in_time))
+    elif isinstance(value, list):
+        for child in value:
+            times.extend(opencode_payload_times(child, inside_time))
+    return times
+
+
+def opencode_text(value):
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def opencode_tool_content_text(content):
+    parts = []
+    if not isinstance(content, list):
+        return parts
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "text" and isinstance(item.get("text"), str):
+            parts.append(item["text"])
+        elif item.get("type") == "file" and isinstance(item.get("uri"), str):
+            parts.append(item["uri"])
+    return parts
+
+
+def opencode_skill_from_tool(tool, state):
+    if (tool.get("tool") or tool.get("name")) != "skill":
+        return None
+    tool_input = state.get("input")
+    if isinstance(tool_input, dict) and isinstance(tool_input.get("name"), str):
+        return tool_input["name"]
+    if state.get("status") != "completed":
+        return None
+    metadata = []
+    metadata.append(state.get("metadata"))
+    for value in (state.get("result"), state.get("structured")):
+        if isinstance(value, dict):
+            metadata.append(value.get("metadata"))
+    provider = tool.get("provider")
+    if isinstance(provider, dict):
+        metadata.append(provider.get("resultMetadata"))
+    for value in metadata:
+        if not isinstance(value, dict):
+            continue
+        candidates = [value.get("name")]
+        candidates.extend(
+            nested.get("name") for nested in value.values() if isinstance(nested, dict)
+        )
+        found = next((name for name in candidates if isinstance(name, str)), None)
+        if found:
+            return found
+    return None
+
+
+def opencode_message_part_rows(connection, session_id, warn):
+    """Adapt shipped message/part rows to the existing normalized decoder."""
+    message_columns = sqlite_table_columns(connection, "message")
+    part_columns = sqlite_table_columns(connection, "part")
+    if not {"id", "session_id", "data"}.issubset(message_columns) or not {
+        "id",
+        "message_id",
+        "data",
+    }.issubset(part_columns):
+        return False, []
+    message_created = "time_created" if "time_created" in message_columns else "NULL"
+    message_updated = "time_updated" if "time_updated" in message_columns else "NULL"
+    messages = connection.execute(
+        f"""
+        SELECT id, data, {message_created} AS time_created,
+               {message_updated} AS time_updated
+        FROM message
+        WHERE session_id = ?
+        ORDER BY time_created ASC, id ASC
+        """,
+        (session_id,),
+    ).fetchall()
+    if not messages:
+        return False, []
+
+    part_created = "time_created" if "time_created" in part_columns else "NULL"
+    part_updated = "time_updated" if "time_updated" in part_columns else "NULL"
+    parts = connection.execute(
+        f"""
+        SELECT id, message_id, data, {part_created} AS time_created,
+               {part_updated} AS time_updated
+        FROM part
+        WHERE message_id IN (SELECT id FROM message WHERE session_id = ?)
+        ORDER BY message_id ASC, id ASC
+        """,
+        (session_id,),
+    ).fetchall()
+    parts_by_message = {}
+    for part in parts:
+        parts_by_message.setdefault(part["message_id"], []).append(part)
+
+    structural = {
+        "compaction",
+        "file",
+        "patch",
+        "reasoning",
+        "retry",
+        "snapshot",
+        "step-finish",
+        "step-start",
+        "subtask",
+    }
+    rows = []
+    for message in messages:
+        try:
+            info = json.loads(message["data"])
+        except (json.JSONDecodeError, TypeError):
+            rows.append(
+                {
+                    "type": "assistant",
+                    "seq": message["id"],
+                    "data": message["data"],
+                    "time_created": message["time_created"],
+                    "time_updated": message["time_updated"],
+                }
+            )
+            continue
+        if not isinstance(info, dict):
+            warn(f"session {session_id} has non-object message data at {message['id']}")
+            continue
+
+        role = info.get("role")
+        content = []
+        part_times = []
+        for part in parts_by_message.get(message["id"], []):
+            part_times.extend((part["time_created"], part["time_updated"]))
+            try:
+                data = json.loads(part["data"])
+            except (json.JSONDecodeError, TypeError):
+                warn(f"session {session_id} has malformed part JSON at {part['id']}")
+                continue
+            if not isinstance(data, dict):
+                warn(f"session {session_id} has non-object part data at {part['id']}")
+                continue
+            part_type = data.get("type")
+            if part_type == "text":
+                text = data.get("text")
+                if isinstance(text, str) and text.strip() and not data.get("ignored"):
+                    content.append(data)
+            elif part_type == "tool":
+                state = data.get("state")
+                if isinstance(state, dict) and state.get("status") in {
+                    "completed",
+                    "error",
+                }:
+                    content.append(data)
+                elif not isinstance(state, dict) or state.get("status") not in {
+                    "pending",
+                    "running",
+                }:
+                    warn(
+                        f"session {session_id} has unknown or malformed tool state at {part['id']}"
+                    )
+            elif part_type not in structural:
+                warn(
+                    f"session {session_id} has unknown part type {part_type!r} at {part['id']}"
+                )
+
+        payload = dict(info)
+        if role == "user":
+            payload["text"] = "\n".join(
+                item["text"] for item in content if item.get("type") == "text"
+            )
+        elif role == "assistant":
+            payload["content"] = content
+        updated_values = [
+            value
+            for value in [message["time_updated"]] + part_times
+            if value is not None
+        ]
+        rows.append(
+            {
+                "type": role,
+                "seq": message["id"],
+                "data": json.dumps(payload, ensure_ascii=False),
+                "time_created": message["time_created"],
+                "time_updated": max(updated_values) if updated_values else None,
+            }
+        )
+    return True, rows
+
+
+def parse_opencode_session(
+    connection, database, session, skill_names, include_subagents, warn
+):
+    """Normalize one current OpenCode SQLite session."""
+    is_child = bool(session["parent_id"])
+    if is_child and not include_subagents:
+        return None
+
+    uses_message_parts, rows = opencode_message_part_rows(
+        connection, session["id"], warn
+    )
+    if not uses_message_parts:
+        message_columns = sqlite_table_columns(connection, "session_message")
+        if {"session_id", "type", "seq", "data"}.issubset(message_columns):
+            created = "time_created" if "time_created" in message_columns else "NULL"
+            updated = "time_updated" if "time_updated" in message_columns else "NULL"
+            rows = connection.execute(
+                f"""
+                SELECT type, seq, data, {created} AS time_created,
+                       {updated} AS time_updated
+                FROM session_message
+                WHERE session_id = ?
+                ORDER BY seq ASC
+                """,
+                (session["id"],),
+            ).fetchall()
+
+    stats = {
+        "user_turns": 0,
+        "assistant_turns": 0,
+        "tool_calls": 0,
+        "repeated_tool_calls": 0,
+        "error_outputs": 0,
+    }
+    entries = []
+    seen_calls = {}
+    skills_used = set()
+    tool_evidence = []
+    times = [
+        parsed
+        for value in (session["time_created"], session["time_updated"])
+        if (parsed := opencode_ms(value))
+    ]
+    has_code_edits = any(
+        session[name] not in (None, 0, "", "[]")
+        for name in (
+            "summary_additions",
+            "summary_deletions",
+            "summary_files",
+            "summary_diffs",
+        )
+    )
+
+    def add_tool_call(name, tool_input):
+        args_text = opencode_text(tool_input)
+        key = hashlib.sha1((name + args_text).encode()).hexdigest()
+        seen_calls[key] = seen_calls.get(key, 0) + 1
+        stats["tool_calls"] += 1
+        if seen_calls[key] > 1:
+            stats["repeated_tool_calls"] += 1
+        tool_evidence.append(args_text)
+        entries.append((f"tool:{name}", truncate(args_text, MAX_TOOL_CHARS)))
+
+    known_message_types = {
+        "agent-switched",
+        "assistant",
+        "compaction",
+        "model-switched",
+        "shell",
+        "synthetic",
+        "system",
+        "user",
+    }
+    for row in rows:
+        times.extend(
+            parsed
+            for value in (row["time_created"], row["time_updated"])
+            if (parsed := opencode_ms(value))
+        )
+        try:
+            data = json.loads(row["data"])
+        except (json.JSONDecodeError, TypeError):
+            warn(f"session {session['id']} has malformed JSON at seq {row['seq']}")
+            continue
+        if not isinstance(data, dict):
+            warn(f"session {session['id']} has non-object data at seq {row['seq']}")
+            continue
+        message_type = row["type"]
+        if message_type not in known_message_types:
+            warn(f"session {session['id']} has unknown message type {message_type!r}")
+            continue
+        times.extend(opencode_payload_times(data))
+        if message_type == "user":
+            text = data.get("text")
+            if isinstance(text, str) and text.strip() and not looks_injected(text):
+                stats["user_turns"] += 1
+                entries.append(("user", truncate(text, MAX_MSG_CHARS)))
+        elif message_type == "assistant":
+            stats["assistant_turns"] += 1
+            snapshot = data.get("snapshot")
+            has_code_edits = has_code_edits or bool(
+                isinstance(snapshot, dict) and snapshot.get("files")
+            )
+            content = data.get("content")
+            if not isinstance(content, list):
+                warn(
+                    f"session {session['id']} has malformed assistant content "
+                    f"at seq {row['seq']}"
+                )
+                continue
+            for item in content:
+                if not isinstance(item, dict):
+                    warn(
+                        f"session {session['id']} has malformed content "
+                        f"at seq {row['seq']}"
+                    )
+                    continue
+                content_type = item.get("type")
+                if content_type == "text":
+                    text = item.get("text")
+                    if isinstance(text, str) and text.strip():
+                        entries.append(("assistant", truncate(text, MAX_MSG_CHARS)))
+                elif content_type == "tool":
+                    state = item.get("state")
+                    if not isinstance(state, dict):
+                        warn(
+                            f"session {session['id']} has malformed tool state "
+                            f"at seq {row['seq']}"
+                        )
+                        continue
+                    status = state.get("status")
+                    if status == "pending":
+                        continue
+                    if status not in {
+                        "running",
+                        "completed",
+                        "error",
+                    } or not isinstance(state.get("input"), dict):
+                        warn(
+                            f"session {session['id']} has unknown or malformed tool state "
+                            f"at seq {row['seq']}"
+                        )
+                        continue
+                    name = str(item.get("tool") or item.get("name") or "unknown")
+                    add_tool_call(name, state["input"])
+                    skill_name = opencode_skill_from_tool(item, state)
+                    if skill_name:
+                        skills_used.add(skill_name)
+                    output_parts = []
+                    if status in {"completed", "error"}:
+                        output_parts = opencode_tool_content_text(state.get("content"))
+                        for key in ("output", "result", "structured"):
+                            if state.get(key) not in (None, {}, []):
+                                output_parts.append(opencode_text(state[key]))
+                    if status == "error":
+                        stats["error_outputs"] += 1
+                        error = state.get("error")
+                        if error:
+                            output_parts.append(opencode_text(error))
+                    if output_parts:
+                        output = "\n".join(output_parts)
+                        tool_evidence.append(output)
+                        entries.append(("output", truncate(output, MAX_TOOL_CHARS)))
+                    if status == "completed" and state.get("outputPaths"):
+                        has_code_edits = True
+                    if (
+                        status == "completed"
+                        and name.lower() in OPENCODE_CODE_EDIT_TOOLS
+                    ):
+                        has_code_edits = True
+                elif content_type != "reasoning":
+                    warn(
+                        f"session {session['id']} has unknown content type "
+                        f"{content_type!r} at seq {row['seq']}"
+                    )
+        elif message_type == "shell":
+            command = data.get("command")
+            if not isinstance(command, str):
+                warn(
+                    f"session {session['id']} has malformed shell command "
+                    f"at seq {row['seq']}"
+                )
+                continue
+            add_tool_call("shell", command)
+            output = data.get("output")
+            if isinstance(output, str) and output:
+                tool_evidence.append(output)
+                entries.append(("output", truncate(output, MAX_TOOL_CHARS)))
+                low = output[:2000].lower()
+                if "error" in low or "failed" in low or "traceback" in low:
+                    stats["error_outputs"] += 1
+    evidence = "\n".join(tool_evidence).replace("\\", "/")
+    first_ts = min(times) if times else None
+    last_ts = max(times) if times else None
+    database_id = opencode_database_identity(database)
+    meta = {
+        "id": f"{database_id}-{session['id']}",
+        "source_id": session["id"],
+        "cwd": session["directory"],
+        "started_at": first_ts.isoformat() if first_ts else None,
+        "originator": "opencode",
+        "thread_source": "subagent" if is_child else None,
+        "database_id": database_id,
+    }
+    stats["first_ts"] = first_ts.isoformat() if first_ts else None
+    stats["last_ts"] = last_ts.isoformat() if last_ts else None
+    stats["has_code_edits"] = has_code_edits
+    return meta, stats, entries, sorted(skills_used), last_ts, evidence
+
+
+def find_opencode_sessions(databases, cutoff, skill_names, include_subagents):
+    records = []
+    scanned = 0
+    usable = []
+    warning_count = 0
+
+    def warn(message):
+        nonlocal warning_count
+        if warning_count < MAX_OPENCODE_WARNINGS:
+            print(f"warning: OpenCode {message}", file=sys.stderr)
+        elif warning_count == MAX_OPENCODE_WARNINGS:
+            print("warning: additional OpenCode warnings suppressed", file=sys.stderr)
+        warning_count += 1
+
+    for database in databases:
+        connection = None
+        try:
+            connection = open_opencode_database(database)
+            if not opencode_database_has_current_schema(connection):
+                warn(f"database {database} does not have the current session schema")
+                continue
+            usable.append(database)
+            columns = sqlite_table_columns(connection, "session")
+            optional = (
+                "parent_id",
+                "directory",
+                "time_created",
+                "time_updated",
+                "summary_additions",
+                "summary_deletions",
+                "summary_files",
+                "summary_diffs",
+            )
+            selections = ["id"] + [
+                name if name in columns else f"NULL AS {name}" for name in optional
+            ]
+            sessions = connection.execute(
+                f"SELECT {', '.join(selections)} FROM session"
+            ).fetchall()
+            scanned += len(sessions)
+            for session in sessions:
+                parsed = parse_opencode_session(
+                    connection,
+                    database,
+                    session,
+                    skill_names,
+                    include_subagents,
+                    warn,
+                )
+                if parsed is None:
+                    continue
+                meta, stats, entries, skills_used, activity, skill_evidence = parsed
+                if activity is None or activity < cutoff:
+                    continue
+                records.append(
+                    {
+                        "meta": meta,
+                        "stats": stats,
+                        "entries": entries,
+                        "skills_used": skills_used,
+                        "skill_evidence": skill_evidence,
+                        "database": database,
+                        "modified_at": activity,
+                    }
+                )
+        except (OSError, sqlite3.Error) as exc:
+            warn(f"could not read database {database}: {exc}")
+        finally:
+            if connection is not None:
+                connection.close()
+    records.sort(key=lambda record: record["modified_at"], reverse=True)
+    return records, scanned, usable
+
+
 def discover_warp_databases(explicit_paths=(), data_dir=None):
     """Find Warp channel databases, preferring explicit paths when provided."""
     candidates = []
@@ -878,16 +1474,19 @@ def detect_skills_from_entries(entries, skill_names):
         for role, text in entries
         if role == "skill" or role.startswith("tool:")
     ).replace("\\", "/")
+    skill_tool_text = "\n".join(
+        text for role, text in entries
+        if role == "skill" or role.lower() == "tool:skill"
+    )
     detected = set()
     for name in skill_names:
         markers = (
             f"skills/{name}/",
             f"{name}/SKILL.md",
             f'"skill": "{name}"',
-            f'"name": "{name}"',
             f'"bundled_skill_id": "{name}"',
         )
-        if any(marker in tool_text for marker in markers):
+        if any(marker in tool_text for marker in markers) or f'"name": "{name}"' in skill_tool_text:
             detected.add(name)
     return detected
 
@@ -902,6 +1501,7 @@ def main():
         sys.exit(2)
     claude_home = Path(args.claude_home).expanduser()
     codex_home = Path(args.codex_home).expanduser()
+    opencode_root = opencode_data_root(args.opencode_data_dir)
     out_dir = Path(args.out).expanduser()
     transcripts_dir = out_dir / "transcripts"
     transcripts_dir.mkdir(parents=True, exist_ok=True)
@@ -992,6 +1592,66 @@ def main():
         print(f"error: Codex home not found at {codex_home}", file=sys.stderr)
         sys.exit(1)
 
+    requested_opencode = args.harness in ("auto", "all", "opencode")
+    opencode_databases = []
+    if requested_opencode:
+        rejected_opencode_paths = []
+        opencode_databases = discover_opencode_databases(
+            args.opencode_db, opencode_root, rejected_opencode_paths
+        )
+        for index, (path, reason) in enumerate(rejected_opencode_paths):
+            if index < MAX_OPENCODE_WARNINGS:
+                print(f"warning: OpenCode database {path}: {reason}", file=sys.stderr)
+            elif index == MAX_OPENCODE_WARNINGS:
+                print(
+                    "warning: additional OpenCode path warnings suppressed",
+                    file=sys.stderr,
+                )
+        if opencode_databases:
+            opencode_records, opencode_scanned, usable_databases = (
+                find_opencode_sessions(
+                    opencode_databases,
+                    cutoff,
+                    skills.keys(),
+                    args.include_subagents,
+                )
+            )
+            if usable_databases:
+                sources["opencode"] = {
+                    "data_root": str(opencode_root),
+                    "databases": [str(path) for path in usable_databases],
+                    "records_scanned": opencode_scanned,
+                    "records_in_window": len(opencode_records),
+                }
+                scanned_count += len(opencode_records)
+                for record in opencode_records:
+                    meta = record["meta"]
+                    if not args.all_conversations and not session_matches_repos(
+                        meta.get("cwd"), repos
+                    ):
+                        continue
+                    in_scope_count += 1
+                    stats = record["stats"]
+                    if stats["assistant_turns"] < 1 or stats["tool_calls"] < 1:
+                        continue
+                    sessions.append(
+                        {
+                            "harness": "opencode",
+                            "meta": meta,
+                            "stats": stats,
+                            "skills_used": record["skills_used"],
+                            "_skill_evidence": record["skill_evidence"],
+                            "file": f"{record['database']}#session/{meta['source_id']}",
+                            "modified_at": record["modified_at"].isoformat(),
+                            "_entries": record["entries"],
+                        }
+                    )
+        if args.harness == "opencode" and "opencode" not in sources:
+            rejected = ", ".join(path for path, _ in rejected_opencode_paths)
+            suffix = f"; rejected explicit paths: {rejected}" if rejected else ""
+            print(f"error: no usable OpenCode databases found{suffix}", file=sys.stderr)
+            sys.exit(1)
+
     requested_warp = args.harness in ("auto", "all", "warp")
     warp_databases = []
     if requested_warp:
@@ -1037,7 +1697,7 @@ def main():
 
     if not sources:
         print(
-            "error: no Claude Code or Codex session home, or Warp conversation database found",
+            "error: no Claude Code, Codex, OpenCode, or Warp conversation source found",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -1054,8 +1714,13 @@ def main():
             session["_entries"],
             skills.keys(),
         )
+        evidence = session.pop("_skill_evidence", "").replace("\\", "/")
+        detected.update(
+            name for name in skills
+            if f"skills/{name}/" in evidence or f"{name}/SKILL.md" in evidence
+        )
         session["skills_used"] = sorted(
-            set(session["skills_used"]) | detected
+            (set(session["skills_used"]) | detected) & set(skills)
         )
 
     sessions.sort(key=lambda session: session["modified_at"], reverse=True)
@@ -1112,6 +1777,8 @@ def main():
         "sources": sources,
         "claude_home": str(claude_home) if "claude" in sources else None,
         "codex_home": str(codex_home) if "codex" in sources else None,
+        "opencode_data_dir": str(opencode_root) if "opencode" in sources else None,
+        "opencode_databases": [str(path) for path in sources.get("opencode", {}).get("databases", [])],
         "warp_databases": [str(path) for path in warp_databases],
         "conversation_scope": conversation_scope,
         "repo": str(repos[0]) if len(repos) == 1 else None,

--- a/.agents/skills/skill-doctor/scripts/collect_sessions.py
+++ b/.agents/skills/skill-doctor/scripts/collect_sessions.py
@@ -800,9 +800,7 @@ def opencode_message_part_rows(connection, session_id, warn):
     return True, rows
 
 
-def parse_opencode_session(
-    connection, database, session, skill_names, include_subagents, warn
-):
+def parse_opencode_session(connection, database, session, include_subagents, warn):
     """Normalize one current OpenCode SQLite session."""
     is_child = bool(session["parent_id"])
     if is_child and not include_subagents:
@@ -1010,7 +1008,7 @@ def parse_opencode_session(
     return meta, stats, entries, sorted(skills_used), last_ts, evidence
 
 
-def find_opencode_sessions(databases, cutoff, skill_names, include_subagents):
+def find_opencode_sessions(databases, cutoff, include_subagents):
     records = []
     scanned = 0
     usable = []
@@ -1055,7 +1053,6 @@ def find_opencode_sessions(databases, cutoff, skill_names, include_subagents):
                     connection,
                     database,
                     session,
-                    skill_names,
                     include_subagents,
                     warn,
                 )
@@ -1612,7 +1609,6 @@ def main():
                 find_opencode_sessions(
                     opencode_databases,
                     cutoff,
-                    skills.keys(),
                     args.include_subagents,
                 )
             )

--- a/.agents/skills/skill-doctor/scripts/test_collect_sessions.py
+++ b/.agents/skills/skill-doctor/scripts/test_collect_sessions.py
@@ -497,7 +497,7 @@ class OpenCodeSessionTests(unittest.TestCase):
             warnings = io.StringIO()
             with redirect_stderr(warnings):
                 records, scanned, usable = find_opencode_sessions(
-                    [database], now - timedelta(seconds=1), {"skill-doctor"}, False
+                    [database], now - timedelta(seconds=1), False
                 )
             self.assertEqual(len(warnings.getvalue().splitlines()), 11)
             self.assertIn(
@@ -531,7 +531,7 @@ class OpenCodeSessionTests(unittest.TestCase):
 
             with redirect_stderr(io.StringIO()):
                 with_children, _, _ = find_opencode_sessions(
-                    [database], now - timedelta(seconds=1), set(), True
+                    [database], now - timedelta(seconds=1), True
                 )
             self.assertEqual(
                 {record["meta"]["source_id"] for record in with_children},
@@ -547,7 +547,7 @@ class OpenCodeSessionTests(unittest.TestCase):
 
             with redirect_stderr(io.StringIO()):
                 outside, _, _ = find_opencode_sessions(
-                    [database], now + timedelta(seconds=4), set(), True
+                    [database], now + timedelta(seconds=4), True
                 )
             self.assertEqual(outside, [])
 
@@ -594,7 +594,7 @@ class OpenCodeSessionTests(unittest.TestCase):
             connection.close()
 
             records, _, _ = find_opencode_sessions(
-                [database], now - timedelta(seconds=1), set(), False
+                [database], now - timedelta(seconds=1), False
             )
             by_id = {record["meta"]["source_id"]: record for record in records}
             self.assertEqual(by_id["preferred"]["entries"], [("user", "message-part")])
@@ -637,7 +637,7 @@ class OpenCodeSessionTests(unittest.TestCase):
                 databases.append(database)
 
             records, _, usable = find_opencode_sessions(
-                databases, now - timedelta(seconds=1), set(), False
+                databases, now - timedelta(seconds=1), False
             )
             self.assertEqual(usable, databases)
             self.assertEqual(
@@ -685,7 +685,7 @@ class OpenCodeSessionTests(unittest.TestCase):
                 reader.close()
 
             records, _, _ = find_opencode_sessions(
-                [database], now - timedelta(seconds=1), set(), False
+                [database], now - timedelta(seconds=1), False
             )
             self.assertEqual(records[0]["entries"], [("user", "from wal")])
             self.assertEqual(writer.execute("PRAGMA journal_mode").fetchone()[0], "wal")
@@ -715,7 +715,7 @@ class OpenCodeSessionTests(unittest.TestCase):
                 [str(identities[0]), str(root / "alias.db"), str(identities[1])], root
             )
             records, _, _ = find_opencode_sessions(
-                discovered, now - timedelta(seconds=1), set(), False
+                discovered, now - timedelta(seconds=1), False
             )
             self.assertEqual(len(discovered), 2)
             self.assertEqual(len({record["meta"]["id"] for record in records}), 2)

--- a/.agents/skills/skill-doctor/scripts/test_collect_sessions.py
+++ b/.agents/skills/skill-doctor/scripts/test_collect_sessions.py
@@ -1,17 +1,27 @@
 #!/usr/bin/env python3
 """Tests for skill-doctor session collection."""
 
+import io
 import json
 import os
+import sqlite3
+import subprocess
+import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest.mock import patch
 
 from collect_sessions import (
     detect_skills_from_entries,
+    discover_opencode_databases,
     discover_skills,
     find_claude_session_files,
+    find_opencode_sessions,
+    opencode_data_root,
+    open_opencode_database,
     parse_claude_session,
     session_matches_repos,
 )
@@ -20,6 +30,99 @@ from collect_sessions import (
 def write_jsonl(path, records):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("\n".join(json.dumps(record) for record in records) + "\n")
+
+
+def create_opencode_schema(connection):
+    connection.executescript(
+        """
+        CREATE TABLE session (
+            id TEXT PRIMARY KEY,
+            parent_id TEXT,
+            directory TEXT,
+            summary_additions INTEGER,
+            summary_deletions INTEGER,
+            summary_files INTEGER,
+            summary_diffs TEXT,
+            time_created INTEGER,
+            time_updated INTEGER
+        );
+        CREATE TABLE session_message (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            type TEXT NOT NULL,
+            seq INTEGER NOT NULL,
+            time_created INTEGER,
+            time_updated INTEGER,
+            data TEXT NOT NULL
+        );
+        CREATE TABLE message (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            time_created INTEGER,
+            time_updated INTEGER,
+            data TEXT NOT NULL
+        );
+        CREATE TABLE part (
+            id TEXT PRIMARY KEY,
+            message_id TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            time_created INTEGER,
+            time_updated INTEGER,
+            data TEXT NOT NULL
+        );
+        """
+    )
+
+
+def insert_opencode_session(connection, session_id, directory, now_ms, parent_id=None):
+    connection.execute(
+        "INSERT INTO session VALUES (?, ?, ?, 0, 0, 0, NULL, ?, ?)",
+        (session_id, parent_id, str(directory), now_ms - 1000, now_ms),
+    )
+
+
+def insert_opencode_message(
+    connection, message_id, session_id, message_type, seq, data, now_ms
+):
+    connection.execute(
+        "INSERT INTO session_message VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            message_id,
+            session_id,
+            message_type,
+            seq,
+            now_ms,
+            now_ms,
+            data if isinstance(data, str) else json.dumps(data),
+        ),
+    )
+
+
+def insert_opencode_v1_message(connection, message_id, session_id, role, now_ms):
+    connection.execute(
+        "INSERT INTO message VALUES (?, ?, ?, ?, ?)",
+        (
+            message_id,
+            session_id,
+            now_ms,
+            now_ms,
+            json.dumps({"role": role, "time": {"created": now_ms}}),
+        ),
+    )
+
+
+def insert_opencode_v1_part(connection, part_id, message_id, session_id, data, now_ms):
+    connection.execute(
+        "INSERT INTO part VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            part_id,
+            message_id,
+            session_id,
+            now_ms,
+            now_ms,
+            data if isinstance(data, str) else json.dumps(data),
+        ),
+    )
 
 
 class ClaudeSessionTests(unittest.TestCase):
@@ -60,6 +163,12 @@ class ClaudeSessionTests(unittest.TestCase):
         self.assertEqual(
             detect_skills_from_entries(entries, {"alpha", "beta", "gamma"}),
             {"alpha", "beta"},
+        )
+        self.assertEqual(
+            detect_skills_from_entries(
+                [("tool:read", '{"name": "gamma"}')], {"gamma"}
+            ),
+            set(),
         )
 
     def test_discovers_parent_sessions_and_optional_subagents(self):
@@ -190,6 +299,585 @@ class ClaudeSessionTests(unittest.TestCase):
             parsed = parse_claude_session(path, set(), True)
             self.assertEqual(parsed[0]["id"], "session-1-child-1")
             self.assertEqual(parsed[0]["thread_source"], "subagent")
+
+
+class OpenCodeSessionTests(unittest.TestCase):
+    def test_discovers_default_channels_and_explicit_replacements_by_file_identity(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            stable = root / "opencode.db"
+            channel = root / "opencode-dev.db"
+            replacement = root / "custom.db"
+            for path in (stable, channel, replacement):
+                path.touch()
+            alias = root / "alias.db"
+            alias.symlink_to(replacement)
+
+            self.assertEqual(
+                discover_opencode_databases(data_dir=root),
+                [channel.resolve(), stable.resolve()],
+            )
+            self.assertEqual(
+                discover_opencode_databases(
+                    ["custom.db", str(alias), "custom.db"], root
+                ),
+                [replacement.resolve()],
+            )
+            rejected = []
+            self.assertEqual(
+                discover_opencode_databases(
+                    [":memory:", "missing.db", str(root)], root, rejected
+                ),
+                [],
+            )
+            self.assertEqual(
+                [Path(path).name for path, _ in rejected],
+                [":memory:", "missing.db", root.name],
+            )
+            with patch.dict(os.environ, {"XDG_DATA_HOME": str(root)}, clear=False):
+                self.assertEqual(opencode_data_root(), root / "opencode")
+
+    def test_normalizes_v1_messages_parts_stats_skills_children_and_cutoff(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            database = root / "opencode.db"
+            repo = root / "repo"
+            repo.mkdir()
+            now = datetime.now(timezone.utc)
+            now_ms = int(now.timestamp() * 1000)
+            connection = sqlite3.connect(database)
+            create_opencode_schema(connection)
+            insert_opencode_session(connection, "root", repo, now_ms)
+            insert_opencode_session(connection, "child", repo, now_ms, "root")
+            connection.execute(
+                "UPDATE session SET summary_additions = 1 WHERE id = 'child'"
+            )
+            insert_opencode_v1_message(
+                connection, "m-assistant", "root", "assistant", now_ms + 2000
+            )
+            insert_opencode_v1_message(
+                connection, "m-user", "root", "user", now_ms + 1000
+            )
+            insert_opencode_v1_part(
+                connection,
+                "a-text",
+                "m-assistant",
+                "root",
+                {"type": "text", "text": "Inspecting."},
+                now_ms + 2000,
+            )
+            insert_opencode_v1_part(
+                connection,
+                "b-hidden",
+                "m-assistant",
+                "root",
+                {"type": "text", "text": "ignored", "ignored": True},
+                now_ms + 2000,
+            )
+            insert_opencode_v1_part(
+                connection,
+                "c-skill",
+                "m-assistant",
+                "root",
+                {
+                    "type": "tool",
+                    "tool": "skill",
+                    "state": {
+                        "status": "completed",
+                        "input": {"name": "skill-doctor"},
+                        "output": "loaded",
+                        "metadata": {"name": "skill-doctor"},
+                    },
+                },
+                now_ms + 3000,
+            )
+            insert_opencode_v1_part(
+                connection,
+                "d-skill-error",
+                "m-assistant",
+                "root",
+                {
+                    "type": "tool",
+                    "tool": "skill",
+                    "state": {
+                        "status": "error",
+                        "input": {"name": "skill-doctor"},
+                        "error": "failed",
+                    },
+                },
+                now_ms + 3000,
+            )
+            insert_opencode_v1_part(
+                connection,
+                "e-edit",
+                "m-assistant",
+                "root",
+                {
+                    "type": "tool",
+                    "tool": "edit",
+                    "state": {
+                        "status": "completed",
+                        "input": {"filePath": "collector.py"},
+                        "output": "updated",
+                    },
+                },
+                now_ms + 4000,
+            )
+            insert_opencode_v1_part(
+                connection,
+                "f-pending",
+                "m-assistant",
+                "root",
+                {
+                    "type": "tool",
+                    "tool": "read",
+                    "state": {"status": "pending", "input": {}},
+                },
+                now_ms + 4000,
+            )
+            insert_opencode_v1_part(
+                connection,
+                "g-reasoning",
+                "m-assistant",
+                "root",
+                {"type": "reasoning", "text": "hidden"},
+                now_ms + 4000,
+            )
+            insert_opencode_v1_part(
+                connection,
+                "u-text",
+                "m-user",
+                "root",
+                {"type": "text", "text": "Fix the collector"},
+                now_ms + 1000,
+            )
+            for index in range(12):
+                insert_opencode_v1_part(
+                    connection,
+                    f"z-unknown-{index:02}",
+                    "m-assistant",
+                    "root",
+                    {"type": "future"},
+                    now_ms + 2000,
+                )
+            insert_opencode_v1_part(
+                connection,
+                "z-malformed",
+                "m-assistant",
+                "root",
+                "{bad json",
+                now_ms + 2000,
+            )
+            connection.execute(
+                "INSERT INTO message VALUES (?, ?, ?, ?, ?)",
+                (
+                    "m-unknown",
+                    "root",
+                    now_ms + 2000,
+                    now_ms + 2000,
+                    json.dumps({"role": "future"}),
+                ),
+            )
+            insert_opencode_v1_message(
+                connection, "child-user", "child", "user", now_ms
+            )
+            insert_opencode_v1_part(
+                connection,
+                "child-text",
+                "child-user",
+                "child",
+                {"type": "text", "text": "child"},
+                now_ms,
+            )
+            connection.commit()
+            connection.close()
+
+            warnings = io.StringIO()
+            with redirect_stderr(warnings):
+                records, scanned, usable = find_opencode_sessions(
+                    [database], now - timedelta(seconds=1), {"skill-doctor"}, False
+                )
+            self.assertEqual(len(warnings.getvalue().splitlines()), 11)
+            self.assertIn(
+                "additional OpenCode warnings suppressed", warnings.getvalue()
+            )
+            self.assertEqual(scanned, 2)
+            self.assertEqual(usable, [database])
+            self.assertEqual(len(records), 1)
+            record = records[0]
+            self.assertEqual(record["meta"]["source_id"], "root")
+            self.assertEqual(record["meta"]["cwd"], str(repo))
+            self.assertEqual(record["skills_used"], ["skill-doctor"])
+            self.assertEqual(record["stats"]["user_turns"], 1)
+            self.assertEqual(record["stats"]["assistant_turns"], 1)
+            self.assertEqual(record["stats"]["tool_calls"], 3)
+            self.assertEqual(record["stats"]["repeated_tool_calls"], 1)
+            self.assertEqual(record["stats"]["error_outputs"], 1)
+            self.assertTrue(record["stats"]["has_code_edits"])
+            self.assertEqual(
+                record["modified_at"],
+                datetime.fromtimestamp((now_ms + 4000) / 1000, tz=timezone.utc),
+            )
+            self.assertEqual(
+                [
+                    entry
+                    for entry in record["entries"]
+                    if entry[0] in {"user", "assistant"}
+                ],
+                [("user", "Fix the collector"), ("assistant", "Inspecting.")],
+            )
+
+            with redirect_stderr(io.StringIO()):
+                with_children, _, _ = find_opencode_sessions(
+                    [database], now - timedelta(seconds=1), set(), True
+                )
+            self.assertEqual(
+                {record["meta"]["source_id"] for record in with_children},
+                {"root", "child"},
+            )
+            child = next(
+                record
+                for record in with_children
+                if record["meta"]["source_id"] == "child"
+            )
+            self.assertEqual(child["meta"]["thread_source"], "subagent")
+            self.assertTrue(child["stats"]["has_code_edits"])
+
+            with redirect_stderr(io.StringIO()):
+                outside, _, _ = find_opencode_sessions(
+                    [database], now + timedelta(seconds=4), set(), True
+                )
+            self.assertEqual(outside, [])
+
+    def test_prefers_message_parts_and_falls_back_per_session(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            database = Path(tmp) / "opencode.db"
+            now = datetime.now(timezone.utc)
+            now_ms = int(now.timestamp() * 1000)
+            connection = sqlite3.connect(database)
+            create_opencode_schema(connection)
+            for session_id in ("preferred", "fallback"):
+                insert_opencode_session(connection, session_id, tmp, now_ms)
+
+            insert_opencode_v1_message(
+                connection, "preferred-user", "preferred", "user", now_ms
+            )
+            insert_opencode_v1_part(
+                connection,
+                "preferred-text",
+                "preferred-user",
+                "preferred",
+                {"type": "text", "text": "message-part"},
+                now_ms,
+            )
+            insert_opencode_message(
+                connection,
+                "ignored-fallback",
+                "preferred",
+                "user",
+                1,
+                {"text": "must-not-merge"},
+                now_ms,
+            )
+            insert_opencode_message(
+                connection,
+                "fallback-user",
+                "fallback",
+                "user",
+                1,
+                {"text": "session-message"},
+                now_ms,
+            )
+            connection.commit()
+            connection.close()
+
+            records, _, _ = find_opencode_sessions(
+                [database], now - timedelta(seconds=1), set(), False
+            )
+            by_id = {record["meta"]["source_id"]: record for record in records}
+            self.assertEqual(by_id["preferred"]["entries"], [("user", "message-part")])
+            self.assertEqual(
+                by_id["fallback"]["entries"], [("user", "session-message")]
+            )
+
+    def test_accepts_either_current_schema_representation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            now = datetime.now(timezone.utc)
+            now_ms = int(now.timestamp() * 1000)
+            databases = []
+            for name, dropped in (
+                ("message-parts.db", ("session_message",)),
+                ("session-message.db", ("message", "part")),
+            ):
+                database = root / name
+                connection = sqlite3.connect(database)
+                create_opencode_schema(connection)
+                for table in dropped:
+                    connection.execute(f"DROP TABLE {table}")
+                insert_opencode_session(connection, name, root, now_ms)
+                if name == "message-parts.db":
+                    insert_opencode_v1_message(
+                        connection, "message", name, "user", now_ms
+                    )
+                else:
+                    insert_opencode_message(
+                        connection,
+                        "message",
+                        name,
+                        "user",
+                        1,
+                        {"text": "fallback"},
+                        now_ms,
+                    )
+                connection.commit()
+                connection.close()
+                databases.append(database)
+
+            records, _, usable = find_opencode_sessions(
+                databases, now - timedelta(seconds=1), set(), False
+            )
+            self.assertEqual(usable, databases)
+            self.assertEqual(
+                {record["meta"]["source_id"] for record in records},
+                {"message-parts.db", "session-message.db"},
+            )
+
+    def test_reads_committed_uncheckpointed_wal_without_mutation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            database = Path(tmp) / "opencode.db"
+            now = datetime.now(timezone.utc)
+            now_ms = int(now.timestamp() * 1000)
+            writer = sqlite3.connect(database)
+            self.assertEqual(
+                writer.execute("PRAGMA journal_mode=WAL").fetchone()[0], "wal"
+            )
+            create_opencode_schema(writer)
+            writer.commit()
+            writer.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            insert_opencode_session(writer, "wal-session", tmp, now_ms)
+            insert_opencode_v1_message(
+                writer, "wal-user", "wal-session", "user", now_ms
+            )
+            insert_opencode_v1_part(
+                writer,
+                "wal-text",
+                "wal-user",
+                "wal-session",
+                {"type": "text", "text": "from wal"},
+                now_ms,
+            )
+            writer.commit()
+            wal = Path(str(database) + "-wal")
+            self.assertGreater(wal.stat().st_size, 0)
+
+            reader = open_opencode_database(database)
+            try:
+                self.assertEqual(reader.execute("PRAGMA query_only").fetchone()[0], 1)
+                self.assertEqual(
+                    reader.execute("SELECT count(*) FROM session").fetchone()[0], 1
+                )
+                with self.assertRaises(sqlite3.OperationalError):
+                    reader.execute("DELETE FROM session")
+            finally:
+                reader.close()
+
+            records, _, _ = find_opencode_sessions(
+                [database], now - timedelta(seconds=1), set(), False
+            )
+            self.assertEqual(records[0]["entries"], [("user", "from wal")])
+            self.assertEqual(writer.execute("PRAGMA journal_mode").fetchone()[0], "wal")
+            self.assertEqual(
+                writer.execute("SELECT count(*) FROM session").fetchone()[0], 1
+            )
+            self.assertGreater(wal.stat().st_size, 0)
+            writer.close()
+
+    def test_deduplicates_physical_databases_but_namespaces_distinct_copies(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            now = datetime.now(timezone.utc)
+            now_ms = int(now.timestamp() * 1000)
+            identities = []
+            for name in ("opencode.db", "opencode-dev.db"):
+                database = root / name
+                connection = sqlite3.connect(database)
+                create_opencode_schema(connection)
+                insert_opencode_session(connection, "same-id", root, now_ms)
+                connection.commit()
+                connection.close()
+                identities.append(database)
+            (root / "alias.db").symlink_to(identities[0])
+
+            discovered = discover_opencode_databases(
+                [str(identities[0]), str(root / "alias.db"), str(identities[1])], root
+            )
+            records, _, _ = find_opencode_sessions(
+                discovered, now - timedelta(seconds=1), set(), False
+            )
+            self.assertEqual(len(discovered), 2)
+            self.assertEqual(len({record["meta"]["id"] for record in records}), 2)
+
+    def test_opencode_cli_writes_source_inventory_and_transcript(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "repo"
+            repo.mkdir()
+            skill = repo / ".agents" / "skills" / "skill-doctor" / "SKILL.md"
+            skill.parent.mkdir(parents=True)
+            skill.write_text("---\ndescription: Grade skills\n---\n")
+            data = root / "data"
+            data.mkdir()
+            database = data / "custom.db"
+            now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+            connection = sqlite3.connect(database)
+            create_opencode_schema(connection)
+            insert_opencode_session(connection, "cli-session", repo, now_ms)
+            insert_opencode_v1_message(
+                connection, "cli-user", "cli-session", "user", now_ms
+            )
+            insert_opencode_v1_part(
+                connection,
+                "cli-user-text",
+                "cli-user",
+                "cli-session",
+                {"type": "text", "text": "grade this"},
+                now_ms,
+            )
+            insert_opencode_v1_message(
+                connection, "cli-assistant", "cli-session", "assistant", now_ms
+            )
+            insert_opencode_v1_part(
+                connection,
+                "cli-skill",
+                "cli-assistant",
+                "cli-session",
+                {
+                    "type": "tool",
+                    "tool": "skill",
+                    "state": {
+                        "status": "completed",
+                        "input": {"name": "skill-doctor"},
+                        "output": "loaded",
+                        "metadata": {"name": "skill-doctor"},
+                    },
+                },
+                now_ms,
+            )
+            connection.commit()
+            connection.close()
+            out = root / "report"
+            script = Path(__file__).resolve().parent / "collect_sessions.py"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "--harness",
+                    "opencode",
+                    "--opencode-data-dir",
+                    str(data),
+                    "--opencode-db",
+                    "custom.db",
+                    "--repo",
+                    str(repo),
+                    "--out",
+                    str(out),
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            inventory = json.loads((out / "inventory.json").read_text())
+            self.assertEqual(inventory["harness"], "opencode")
+            self.assertEqual(list(inventory["sources"]), ["opencode"])
+            self.assertEqual(inventory["opencode_databases"], [str(database.resolve())])
+            self.assertEqual(inventory["stats"]["sessions_sampled"], 1)
+            self.assertEqual(inventory["stats"]["session_records_in_window"], 1)
+            self.assertEqual(inventory["sessions"][0]["skills_used"], ["skill-doctor"])
+            transcript = Path(inventory["sessions"][0]["transcript_path"])
+            self.assertIn("[user] grade this", transcript.read_text())
+
+            subprocess.run(
+                ["git", "init", str(repo)], capture_output=True, check=True, text=True
+            )
+            all_out = root / "all-report"
+            all_result = subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "--harness",
+                    "opencode",
+                    "--opencode-data-dir",
+                    str(data),
+                    "--opencode-db",
+                    "custom.db",
+                    "--all-conversations",
+                    "--out",
+                    str(all_out),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(all_result.returncode, 0, all_result.stderr)
+            all_inventory = json.loads((all_out / "inventory.json").read_text())
+            self.assertEqual(
+                all_inventory["sessions"][0]["skills_used"], ["skill-doctor"]
+            )
+
+            missing = subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "--harness",
+                    "opencode",
+                    "--opencode-data-dir",
+                    str(data),
+                    "--opencode-db",
+                    "missing.db",
+                    "--all-conversations",
+                    "--out",
+                    str(root / "missing-report"),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(missing.returncode, 1)
+            self.assertIn("no usable OpenCode databases found", missing.stderr)
+            self.assertIn(str(data / "missing.db"), missing.stderr)
+
+            claude_projects = root / "claude" / "projects"
+            claude_projects.mkdir(parents=True)
+            mixed = subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "--harness",
+                    "all",
+                    "--claude-home",
+                    str(root / "claude"),
+                    "--codex-home",
+                    str(root / "missing-codex"),
+                    "--opencode-data-dir",
+                    str(data),
+                    "--opencode-db",
+                    "missing.db",
+                    "--warp-data-dir",
+                    str(root / "missing-warp"),
+                    "--all-conversations",
+                    "--out",
+                    str(root / "mixed-report"),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(mixed.returncode, 0, mixed.stderr)
+            self.assertIn(
+                f"warning: OpenCode database {data / 'missing.db'}", mixed.stderr
+            )
 
 
 if __name__ == "__main__":

--- a/.agents/skills/skill-doctor/scripts/test_render_report.py
+++ b/.agents/skills/skill-doctor/scripts/test_render_report.py
@@ -48,6 +48,7 @@ class ReportRendererTests(unittest.TestCase):
         self.assertIn("| Warp | `warp` |", harness_text)
         self.assertIn("| Claude Code | `claude` |", harness_text)
         self.assertIn("| Codex | `codex` |", harness_text)
+        self.assertIn("| OpenCode | `opencode` |", harness_text)
         self.assertIn("stop before creating a report directory", harness_text)
 
     def test_code_diffs_follow_os_theme(self):


### PR DESCRIPTION
Closes #86

Adds OpenCode support to `skill-doctor`, allowing it to grade local OpenCode conversations instead of stopping at harness validation.

The collector reads OpenCode SQLite databases locally and in read-only mode. It prefers the active `message`/`part` representation and falls back to `session_message` per session. Transcript data remains local.

## Review guide

Start with the OpenCode decoder in `collect_sessions.py`. Focus on schema selection, WAL-safe database access, and transcript normalization. The tests cover both schemas and their precedence.

## What changed

- Added OpenCode harness detection and CLI options.
- Added default and explicit database discovery.
- Normalized messages, tool calls, errors, code edits, skill usage, and child sessions.
- Added bounded diagnostics for malformed data and unusable database paths.
- Added fixtures for schema precedence, fallback behavior, filtering, statistics, and live WAL reads.

## Validation

- `python3 -m unittest test_collect_sessions.py test_render_report.py` — 23 tests passed.
- Python 3.9 test suite — 23 tests passed.
- `py_compile` passed on both Python versions.
- `git diff --check` passed.
- A read-only smoke test against OpenCode v1.18.25 found and sampled two scoreable repository sessions.