### PR TITLE
feat(skill-doctor): add Pi, Grok Build and ZCode harness support

### DIFF
--- a/.agents/skills/skill-doctor/references/supported-harnesses.md
+++ b/.agents/skills/skill-doctor/references/supported-harnesses.md
@@ -9,12 +9,15 @@ This file is the single source of truth for harness support in `skill-doctor`. R
 | Warp | `warp` | Read-only Warp conversation databases |
 | Claude Code | `claude` | Project-history JSONL |
 | Codex | `codex` | Rollout JSONL |
+| Pi | `pi` | Pi agent JSONL (`~/.pi/agent/sessions`) |
+| Grok Build | `grok` | Grok Build chat_history JSONL (`~/.grok/sessions`) |
+| ZCode | `zcode` | ZCode model-io rollout (`~/.zcode/cli/rollout`) |
 
 At startup, identify the harness executing the skill from the runtime context. Do not infer it from conversation files found on disk.
 
 If the executing harness is not listed above, or cannot be identified confidently, stop before creating a report directory or reading conversation history. Tell the user:
 
-> skill-doctor currently supports Warp, Claude Code, and Codex. This run appears to be using an unsupported harness, so no conversations were read.
+> skill-doctor currently supports Warp, Claude Code, Codex, Pi, Grok Build, and ZCode. This run appears to be using an unsupported harness, so no conversations were read.
 
 ## Collector source selection
 
@@ -29,6 +32,9 @@ Harness-specific source overrides:
 - `--codex-home PATH` — nonstandard Codex home.
 - `--warp-db PATH` — explicit Warp database; repeatable.
 - `--warp-data-dir PATH` — nonstandard Warp channel-data directory.
+- `--pi-home PATH` — nonstandard Pi agent home (default `~/.pi/agent`).
+- `--grok-home PATH` — nonstandard Grok Build home (default `~/.grok`).
+- `--zcode-home PATH` — nonstandard ZCode home (default `~/.zcode`).
 
 ## Skill locations
 
@@ -38,4 +44,4 @@ Project skills are discovered from:
 - `.claude/skills`
 - `.codex/skills`
 
-Global skills are discovered from the corresponding directories under the user's home and configured harness homes when `--include-global-skills` is set.
+Global skills are discovered from the corresponding directories under the user's home and configured harness homes when `--include-global-skills` is set: `~/.claude/skills`, `~/.agents/skills`, `~/.codex/skills`, Pi's skill directory under its agent home (default `~/.pi/agent/skills`), Grok Build's `~/.grok/skills`, and ZCode's `~/.zcode/skills`.

--- a/.agents/skills/skill-doctor/scripts/collect_sessions.py
+++ b/.agents/skills/skill-doctor/scripts/collect_sessions.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Collect local Claude Code, Codex, and Warp sessions and skills for scoring.
+"""Collect local Claude Code, Codex, Warp, Pi, Grok Build, and ZCode sessions and skills for scoring.
 
-Scans Claude Code project history, Codex rollout files, and/or Warp's local
-conversation databases, discovers installed skills, detects which sessions
-used which skills, and emits:
+Scans Claude Code project history, Codex rollout files, Warp's local
+conversation databases, Pi agent session JSONL, Grok Build chat history,
+and/or ZCode model-io rollouts, discovers installed skills, detects which
+sessions used which skills, and emits:
 
   <out>/inventory.json        - skills, per-session stats, sampling decisions
   <out>/transcripts/<id>.md   - condensed transcripts for sampled sessions
@@ -21,6 +22,7 @@ import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from urllib.parse import unquote
 from warp_decoder import ProtobufDecodeError, decode_task
 
 MAX_FILE_BYTES = 8 * 1024 * 1024
@@ -33,13 +35,14 @@ TRANSCRIPT_TAIL = 40
 
 CODE_EDIT_HINTS = ("apply_patch", "*** Begin Patch", "edit_file", "create_file", "str_replace", "write_file")
 CLAUDE_CODE_EDIT_TOOLS = {"Edit", "MultiEdit", "NotebookEdit", "Write"}
+GENERIC_EDIT_TOOLS = {"edit", "write", "apply_patch", "edit_file", "write_file", "str_replace", "search_replace"}
 
 
 def parse_args():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument(
         "--harness",
-        choices=("auto", "all", "claude", "codex", "warp"),
+        choices=("auto", "all", "claude", "codex", "warp", "pi", "grok", "zcode"),
         default="auto",
         help="session source (default: auto; scans every locally available source)",
     )
@@ -49,6 +52,21 @@ def parse_args():
         help="Claude Code config directory (default: CLAUDE_CONFIG_DIR or ~/.claude)",
     )
     p.add_argument("--codex-home", default=os.environ.get("CODEX_HOME", "~/.codex"))
+    p.add_argument(
+        "--pi-home",
+        default="~/.pi/agent",
+        help="Pi agent home (default: ~/.pi/agent)",
+    )
+    p.add_argument(
+        "--grok-home",
+        default="~/.grok",
+        help="Grok Build home (default: ~/.grok)",
+    )
+    p.add_argument(
+        "--zcode-home",
+        default="~/.zcode",
+        help="ZCode home (default: ~/.zcode)",
+    )
     p.add_argument(
         "--warp-db",
         action="append",
@@ -72,7 +90,7 @@ def parse_args():
         help="score conversations from every project represented in local history",
     )
     p.add_argument("--include-global-skills", action="store_true",
-                   help="also discover skills outside the repo (~/.codex/skills, ~/.agents/skills, ~/.claude/skills)")
+                   help="also discover skills outside the repo (~/.codex/skills, ~/.agents/skills, ~/.claude/skills, ~/.pi/agent/skills, ~/.grok/skills, ~/.zcode/skills)")
     p.add_argument("--days", type=int, default=45, help="only consider sessions modified in the last N days")
     p.add_argument("--max-sessions", type=int, default=12, help="max sessions to sample for scoring")
     p.add_argument("--per-skill", type=int, default=3, help="max sampled sessions per skill")
@@ -111,7 +129,8 @@ def resolve_repos(repo_args):
     return repos
 
 
-def discover_skills(repos, codex_home: Path, extra_dirs, include_global: bool):
+def discover_skills(repos, codex_home: Path, extra_dirs, include_global: bool,
+                    pi_home: Path = None, grok_home: Path = None, zcode_home: Path = None):
     if isinstance(repos, Path):
         repos = [repos]
     roots = []
@@ -121,12 +140,15 @@ def discover_skills(repos, codex_home: Path, extra_dirs, include_global: bool):
             repo / ".claude" / "skills",
             repo / ".codex" / "skills",
         ))
-    if include_global:
-        roots += [
-            codex_home / "skills",
-            Path.home() / ".agents" / "skills",
-            Path.home() / ".claude" / "skills",
-        ]
+        if include_global:
+            roots += [
+                codex_home / "skills",
+                Path.home() / ".agents" / "skills",
+                Path.home() / ".claude" / "skills",
+            ]
+            for home in (pi_home, grok_home, zcode_home):
+                if home is not None:
+                    roots.append(Path(home) / "skills")
     roots += [Path(d).expanduser() for d in extra_dirs]
 
     skills = {}
@@ -366,6 +388,7 @@ def looks_injected(text: str) -> bool:
         for tag in (
             "environment_context", "user_instructions", "ENVIRONMENT", "system-reminder",
             "permissions", "collaboration_mode", "recommended_plugins", "turn_context",
+            "user_info",
         )
     )
 
@@ -793,6 +816,375 @@ def parse_warp_conversation(record, skill_names, include_subagents):
     return meta, stats, entries, sorted(skills_used)
 
 
+def find_pi_session_files(pi_home: Path, cutoff: datetime):
+    root = pi_home / "sessions"
+    if not root.is_dir():
+        return []
+    files = []
+    for path in root.glob("*/*.jsonl"):
+        try:
+            mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        except OSError:
+            continue
+        if mtime >= cutoff:
+            files.append((mtime, path))
+    files.sort(key=lambda item: item[0], reverse=True)
+    return files
+
+
+def parse_pi_session(path: Path, skill_names, include_subagents: bool):
+    """Normalize one Pi agent JSONL session to the shared transcript shape.
+
+    Pi has no subagent sessions; include_subagents is accepted for signature
+    compatibility with the Claude parser and ignored.
+    """
+    try:
+        raw = path.read_text(errors="replace")
+    except OSError:
+        return None
+    if len(raw) > MAX_FILE_BYTES:
+        raw = raw[:MAX_FILE_BYTES]
+
+    meta = {}
+    stats = {"user_turns": 0, "assistant_turns": 0, "tool_calls": 0, "repeated_tool_calls": 0, "error_outputs": 0}
+    entries = []
+    seen_calls = {}
+    call_args_text = []
+    used_tool_names = set()
+    first_ts = last_ts = None
+
+    for line in raw.splitlines():
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        record_type = obj.get("type")
+        ts = obj.get("timestamp")
+        if ts:
+            first_ts = first_ts or ts
+            last_ts = ts
+
+        if record_type == "session":
+            if not meta:
+                meta = {
+                    "id": obj.get("id") or path.stem,
+                    "cwd": obj.get("cwd"),
+                    "started_at": ts,
+                    "originator": "pi",
+                    "thread_source": None,
+                }
+            else:
+                meta["cwd"] = meta.get("cwd") or obj.get("cwd")
+                meta["started_at"] = meta.get("started_at") or ts
+            continue
+
+        if record_type != "message":
+            continue
+        message = obj.get("message")
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        content = message.get("content")
+        blocks = content if isinstance(content, list) else [{"type": "text", "text": content}]
+
+        if role == "toolResult":
+            message_error = bool(message.get("isError"))
+            for block in blocks:
+                if not isinstance(block, dict):
+                    continue
+                result = block.get("text") or ""
+                if not isinstance(result, str) or not result:
+                    continue
+                low = result[:2000].lower()
+                if (
+                    message_error
+                    or block.get("isError")
+                    or "error" in low
+                    or "failed" in low
+                    or "traceback" in low
+                ):
+                    stats["error_outputs"] += 1
+                entries.append(("output", truncate(result, MAX_TOOL_CHARS)))
+            continue
+
+        has_user_text = False
+        if role == "assistant":
+            stats["assistant_turns"] += 1
+
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type")
+            if block_type == "text":
+                text = block.get("text")
+                if not isinstance(text, str) or not text or looks_injected(text):
+                    continue
+                if role == "user":
+                    has_user_text = True
+                    entries.append(("user", truncate(text, MAX_MSG_CHARS)))
+                elif role == "assistant":
+                    entries.append(("assistant", truncate(text, MAX_MSG_CHARS)))
+            elif block_type == "toolCall":
+                stats["tool_calls"] += 1
+                name = str(block.get("name") or "unknown")
+                args = block.get("arguments") or {}
+                args_text = args if isinstance(args, str) else json.dumps(args, ensure_ascii=False)
+                key = hashlib.sha1((name + args_text).encode()).hexdigest()
+                seen_calls[key] = seen_calls.get(key, 0) + 1
+                if seen_calls[key] > 1:
+                    stats["repeated_tool_calls"] += 1
+                call_args_text.append(args_text)
+                used_tool_names.add(name)
+                entries.append((f"tool:{name}", truncate(args_text, MAX_TOOL_CHARS)))
+
+        if role == "user" and has_user_text:
+            stats["user_turns"] += 1
+
+    if not meta:
+        meta = {
+            "id": path.stem,
+            "cwd": None,
+            "started_at": first_ts,
+            "originator": "pi",
+            "thread_source": None,
+        }
+
+    args_blob = "\n".join(call_args_text)
+    skills_used = sorted(
+        name for name in skill_names
+        if f"skills/{name}/" in args_blob or f"{name}/SKILL.md" in args_blob
+    )
+    stats["first_ts"] = first_ts
+    stats["last_ts"] = last_ts
+    stats["has_code_edits"] = (
+        bool(used_tool_names & GENERIC_EDIT_TOOLS)
+        or any(hint in args_blob for hint in CODE_EDIT_HINTS)
+    )
+    return meta, stats, entries, skills_used
+
+
+def find_grok_session_files(grok_home: Path, cutoff: datetime):
+    root = grok_home / "sessions"
+    if not root.is_dir():
+        return []
+    files = []
+    for path in root.glob("*/*/chat_history.jsonl"):
+        try:
+            mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        except OSError:
+            continue
+        if mtime >= cutoff:
+            files.append((mtime, path))
+    files.sort(key=lambda item: item[0], reverse=True)
+    return files
+
+
+def assistant_tool_calls(message):
+    """Extract (name, args_text) pairs from OpenAI-style tool_calls entries."""
+    calls = []
+    for call in message.get("tool_calls") or []:
+        if not isinstance(call, dict):
+            continue
+        fn = call.get("function") or {}
+        name = call.get("name") or fn.get("name") or "unknown"
+        args = call.get("arguments")
+        if args is None:
+            args = fn.get("arguments")
+        if not isinstance(args, str):
+            args = json.dumps(args, ensure_ascii=False)
+        calls.append((str(name), args))
+    return calls
+
+
+def parse_grok_session(path: Path, skill_names, include_subagents: bool):
+    """Normalize one Grok Build chat_history.jsonl to the shared transcript shape.
+
+    Grok stores a session as one flat file; subagent activity appears as
+    synthetic_reason injections which are skipped, so include_subagents is
+    accepted for signature compatibility and ignored.
+    """
+    try:
+        raw = path.read_text(errors="replace")
+    except OSError:
+        return None
+    if len(raw) > MAX_FILE_BYTES:
+        raw = raw[:MAX_FILE_BYTES]
+
+    stats = {"user_turns": 0, "assistant_turns": 0, "tool_calls": 0, "repeated_tool_calls": 0, "error_outputs": 0}
+    entries = []
+    seen_calls = {}
+    call_args_text = []
+    used_tool_names = set()
+
+    for line in raw.splitlines():
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        record_type = obj.get("type")
+        if record_type in ("system", "reasoning", "backend_tool_call"):
+            continue
+        if obj.get("synthetic_reason"):
+            continue
+
+        if record_type == "user":
+            text = extract_text(obj.get("content"))
+            if not text or looks_injected(text):
+                continue
+            stats["user_turns"] += 1
+            entries.append(("user", truncate(text, MAX_MSG_CHARS)))
+        elif record_type == "assistant":
+            text = extract_text(obj.get("content"))
+            if text:
+                stats["assistant_turns"] += 1
+                entries.append(("assistant", truncate(text, MAX_MSG_CHARS)))
+            for name, args_text in assistant_tool_calls(obj):
+                stats["tool_calls"] += 1
+                key = hashlib.sha1((name + args_text).encode()).hexdigest()
+                seen_calls[key] = seen_calls.get(key, 0) + 1
+                if seen_calls[key] > 1:
+                    stats["repeated_tool_calls"] += 1
+                call_args_text.append(args_text)
+                used_tool_names.add(name)
+                entries.append((f"tool:{name}", truncate(args_text, MAX_TOOL_CHARS)))
+        elif record_type == "tool_result":
+            result = extract_text(obj.get("content"))
+            if not result:
+                continue
+            low = result[:2000].lower()
+            if "error" in low or "failed" in low or "traceback" in low:
+                stats["error_outputs"] += 1
+            entries.append(("output", truncate(result, MAX_TOOL_CHARS)))
+
+    meta = {
+        "id": path.parent.name,
+        "cwd": unquote(path.parent.parent.name),
+        "started_at": None,
+        "originator": "grok",
+        "thread_source": None,
+    }
+    args_blob = "\n".join(call_args_text)
+    skills_used = sorted(
+        name for name in skill_names
+        if f"skills/{name}/" in args_blob or f"{name}/SKILL.md" in args_blob
+    )
+    stats["first_ts"] = None
+    stats["last_ts"] = None
+    stats["has_code_edits"] = (
+        bool(used_tool_names & GENERIC_EDIT_TOOLS)
+        or any(hint in args_blob for hint in CODE_EDIT_HINTS)
+    )
+    return meta, stats, entries, skills_used
+
+
+def find_zcode_session_files(zcode_home: Path, cutoff: datetime):
+    root = zcode_home / "cli" / "rollout"
+    if not root.is_dir():
+        return []
+    files = []
+    for path in root.glob("model-io-*.jsonl"):
+        try:
+            mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        except OSError:
+            continue
+        if mtime >= cutoff:
+            files.append((mtime, path))
+    files.sort(key=lambda item: item[0], reverse=True)
+    return files
+
+
+def parse_zcode_session(path: Path, skill_names, include_subagents: bool):
+    """Normalize one ZCode model-io rollout to the shared transcript shape.
+
+    Model-io logs are request dumps: only the last request's message list is
+    reconstructed, so stats describe the final context window rather than the
+    full session.
+    """
+    try:
+        raw = path.read_text(errors="replace")
+    except OSError:
+        return None
+    if len(raw) > MAX_FILE_BYTES:
+        raw = raw[:MAX_FILE_BYTES]
+
+    messages = None
+    for line in raw.splitlines():
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(obj, dict):
+            continue
+        body = (obj.get("request") or {}).get("body") or {}
+        candidate = body.get("messages")
+        if isinstance(candidate, list) and candidate:
+            messages = candidate
+    if not messages:
+        return None
+
+    stats = {"user_turns": 0, "assistant_turns": 0, "tool_calls": 0, "repeated_tool_calls": 0, "error_outputs": 0}
+    entries = []
+    seen_calls = {}
+    call_args_text = []
+    used_tool_names = set()
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        if role == "user":
+            text = extract_text(message.get("content"))
+            if not text or looks_injected(text):
+                continue
+            stats["user_turns"] += 1
+            entries.append(("user", truncate(text, MAX_MSG_CHARS)))
+        elif role == "assistant":
+            text = extract_text(message.get("content"))
+            if text:
+                stats["assistant_turns"] += 1
+                entries.append(("assistant", truncate(text, MAX_MSG_CHARS)))
+            for name, args_text in assistant_tool_calls(message):
+                stats["tool_calls"] += 1
+                key = hashlib.sha1((name + args_text).encode()).hexdigest()
+                seen_calls[key] = seen_calls.get(key, 0) + 1
+                if seen_calls[key] > 1:
+                    stats["repeated_tool_calls"] += 1
+                call_args_text.append(args_text)
+                used_tool_names.add(name)
+                entries.append((f"tool:{name}", truncate(args_text, MAX_TOOL_CHARS)))
+        elif role == "tool":
+            result = extract_text(message.get("content"))
+            if not result:
+                continue
+            low = result[:2000].lower()
+            if "error" in low or "failed" in low or "traceback" in low:
+                stats["error_outputs"] += 1
+            entries.append(("output", truncate(result, MAX_TOOL_CHARS)))
+
+    if not entries:
+        return None
+
+    meta = {
+        "id": path.stem.removeprefix("model-io-"),
+        "cwd": None,
+        "started_at": None,
+        "originator": "zcode",
+        "thread_source": None,
+    }
+    args_blob = "\n".join(call_args_text)
+    skills_used = sorted(
+        name for name in skill_names
+        if f"skills/{name}/" in args_blob or f"{name}/SKILL.md" in args_blob
+    )
+    stats["first_ts"] = None
+    stats["last_ts"] = None
+    stats["has_code_edits"] = (
+        bool(used_tool_names & GENERIC_EDIT_TOOLS)
+        or any(hint in args_blob for hint in CODE_EDIT_HINTS)
+    )
+    return meta, stats, entries, skills_used
+
+
 def render_transcript(meta, stats, skills_used, entries) -> str:
     lines = [
         f"# Session {meta.get('id')}",
@@ -902,6 +1294,9 @@ def main():
         sys.exit(2)
     claude_home = Path(args.claude_home).expanduser()
     codex_home = Path(args.codex_home).expanduser()
+    pi_home = Path(args.pi_home).expanduser()
+    grok_home = Path(args.grok_home).expanduser()
+    zcode_home = Path(args.zcode_home).expanduser()
     out_dir = Path(args.out).expanduser()
     transcripts_dir = out_dir / "transcripts"
     transcripts_dir.mkdir(parents=True, exist_ok=True)
@@ -912,6 +1307,9 @@ def main():
         codex_home,
         args.skills_dir,
         args.include_global_skills,
+        pi_home=pi_home,
+        grok_home=grok_home,
+        zcode_home=zcode_home,
     )
     cutoff = datetime.now(timezone.utc) - timedelta(days=args.days)
 
@@ -1035,9 +1433,105 @@ def main():
             print("error: no Warp conversation databases found", file=sys.stderr)
             sys.exit(1)
 
+    requested_pi = args.harness in ("auto", "all", "pi")
+    if requested_pi and (pi_home / "sessions").is_dir():
+        pi_files = find_pi_session_files(pi_home, cutoff)
+        sources["pi"] = {"home": str(pi_home), "records_in_window": len(pi_files)}
+        scanned_count += len(pi_files)
+        for mtime, path in pi_files:
+            parsed = parse_pi_session(path, skills.keys(), args.include_subagents)
+            if parsed is None:
+                continue
+            meta, stats, entries, skills_used = parsed
+            if not args.all_conversations and not session_matches_repos(
+                meta.get("cwd"),
+                repos,
+            ):
+                continue
+            in_scope_count += 1
+            if stats["assistant_turns"] < 1 or stats["tool_calls"] < 1:
+                continue
+            sessions.append({
+                "harness": "pi",
+                "meta": meta,
+                "stats": stats,
+                "skills_used": skills_used,
+                "file": str(path),
+                "modified_at": mtime.isoformat(),
+                "_entries": entries,
+            })
+    elif args.harness == "pi":
+        print(f"error: Pi session home not found at {pi_home / 'sessions'}", file=sys.stderr)
+        sys.exit(1)
+
+    requested_grok = args.harness in ("auto", "all", "grok")
+    if requested_grok and (grok_home / "sessions").is_dir():
+        grok_files = find_grok_session_files(grok_home, cutoff)
+        sources["grok"] = {"home": str(grok_home), "records_in_window": len(grok_files)}
+        scanned_count += len(grok_files)
+        for mtime, path in grok_files:
+            parsed = parse_grok_session(path, skills.keys(), args.include_subagents)
+            if parsed is None:
+                continue
+            meta, stats, entries, skills_used = parsed
+            if not args.all_conversations and not session_matches_repos(
+                meta.get("cwd"),
+                repos,
+            ):
+                continue
+            in_scope_count += 1
+            if stats["assistant_turns"] < 1 or stats["tool_calls"] < 1:
+                continue
+            sessions.append({
+                "harness": "grok",
+                "meta": meta,
+                "stats": stats,
+                "skills_used": skills_used,
+                "file": str(path),
+                "modified_at": mtime.isoformat(),
+                "_entries": entries,
+            })
+    elif args.harness == "grok":
+        print(f"error: Grok Build session home not found at {grok_home / 'sessions'}", file=sys.stderr)
+        sys.exit(1)
+
+    requested_zcode = args.harness in ("auto", "all", "zcode")
+    if requested_zcode and (zcode_home / "cli" / "rollout").is_dir():
+        zcode_files = find_zcode_session_files(zcode_home, cutoff)
+        sources["zcode"] = {"home": str(zcode_home), "records_in_window": len(zcode_files)}
+        scanned_count += len(zcode_files)
+        for mtime, path in zcode_files:
+            parsed = parse_zcode_session(path, skills.keys(), args.include_subagents)
+            if parsed is None:
+                continue
+            meta, stats, entries, skills_used = parsed
+            if not args.all_conversations and not session_matches_repos(
+                meta.get("cwd"),
+                repos,
+            ):
+                continue
+            in_scope_count += 1
+            if stats["assistant_turns"] < 1 or stats["tool_calls"] < 1:
+                continue
+            sessions.append({
+                "harness": "zcode",
+                "meta": meta,
+                "stats": stats,
+                "skills_used": skills_used,
+                "file": str(path),
+                "modified_at": mtime.isoformat(),
+                "_entries": entries,
+            })
+    elif args.harness == "zcode":
+        print(
+            f"error: ZCode model-io rollouts not found at {zcode_home / 'cli' / 'rollout'}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     if not sources:
         print(
-            "error: no Claude Code or Codex session home, or Warp conversation database found",
+            "error: no supported session source found (Claude Code, Codex, Warp, Pi, Grok, or ZCode)",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -1048,6 +1542,9 @@ def main():
             codex_home,
             args.skills_dir,
             args.include_global_skills,
+            pi_home=pi_home,
+            grok_home=grok_home,
+            zcode_home=zcode_home,
         )
     for session in sessions:
         detected = detect_skills_from_entries(
@@ -1112,6 +1609,9 @@ def main():
         "sources": sources,
         "claude_home": str(claude_home) if "claude" in sources else None,
         "codex_home": str(codex_home) if "codex" in sources else None,
+        "pi_home": str(pi_home) if "pi" in sources else None,
+        "grok_home": str(grok_home) if "grok" in sources else None,
+        "zcode_home": str(zcode_home) if "zcode" in sources else None,
         "warp_databases": [str(path) for path in warp_databases],
         "conversation_scope": conversation_scope,
         "repo": str(repos[0]) if len(repos) == 1 else None,

--- a/.agents/skills/skill-doctor/scripts/collect_sessions.py
+++ b/.agents/skills/skill-doctor/scripts/collect_sessions.py
@@ -140,15 +140,15 @@ def discover_skills(repos, codex_home: Path, extra_dirs, include_global: bool,
             repo / ".claude" / "skills",
             repo / ".codex" / "skills",
         ))
-        if include_global:
-            roots += [
-                codex_home / "skills",
-                Path.home() / ".agents" / "skills",
-                Path.home() / ".claude" / "skills",
-            ]
-            for home in (pi_home, grok_home, zcode_home):
-                if home is not None:
-                    roots.append(Path(home) / "skills")
+    if include_global:
+        roots += [
+            codex_home / "skills",
+            Path.home() / ".agents" / "skills",
+            Path.home() / ".claude" / "skills",
+        ]
+        for home in (pi_home, grok_home, zcode_home):
+            if home is not None:
+                roots.append(Path(home) / "skills")
     roots += [Path(d).expanduser() for d in extra_dirs]
 
     skills = {}

--- a/.agents/skills/skill-doctor/scripts/test_collect_sessions.py
+++ b/.agents/skills/skill-doctor/scripts/test_collect_sessions.py
@@ -12,7 +12,12 @@ from collect_sessions import (
     detect_skills_from_entries,
     discover_skills,
     find_claude_session_files,
+    find_grok_session_files,
+    find_pi_session_files,
     parse_claude_session,
+    parse_grok_session,
+    parse_pi_session,
+    parse_zcode_session,
     session_matches_repos,
 )
 
@@ -190,6 +195,245 @@ class ClaudeSessionTests(unittest.TestCase):
             parsed = parse_claude_session(path, set(), True)
             self.assertEqual(parsed[0]["id"], "session-1-child-1")
             self.assertEqual(parsed[0]["thread_source"], "subagent")
+
+
+class PiSessionTests(unittest.TestCase):
+    def test_parses_messages_tools_skills_and_stats(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "2026-08-20T10-00-00-000Z_session-1.jsonl"
+            write_jsonl(path, [
+                {
+                    "type": "session",
+                    "id": "session-1",
+                    "cwd": "/tmp/repo",
+                    "timestamp": "2026-08-20T10:00:00.000Z",
+                },
+                {"type": "model_change", "provider": "zai", "modelId": "glm"},
+                {
+                    "type": "message",
+                    "timestamp": "2026-08-20T10:00:01.000Z",
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "Improve my skill"}],
+                    },
+                },
+                {
+                    "type": "message",
+                    "timestamp": "2026-08-20T10:00:02.000Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "thinking", "thinking": "plan the edit"},
+                            {"type": "text", "text": "I will inspect it."},
+                            {
+                                "type": "toolCall",
+                                "name": "read",
+                                "arguments": {
+                                    "path": "/repo/.agents/skills/update-skill/SKILL.md"
+                                },
+                            },
+                        ],
+                    },
+                },
+                {
+                    "type": "message",
+                    "timestamp": "2026-08-20T10:00:03.000Z",
+                    "message": {
+                        "role": "toolResult",
+                        "toolName": "read",
+                        "content": [{"type": "text", "text": "--- description: alpha"}],
+                    },
+                },
+                {
+                    "type": "message",
+                    "timestamp": "2026-08-20T10:00:04.000Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "toolCall",
+                                "name": "edit",
+                                "arguments": {
+                                    "path": "/tmp/repo/SKILL.md",
+                                    "oldText": "a",
+                                    "newText": "b",
+                                },
+                            },
+                        ],
+                    },
+                },
+                {
+                    "type": "message",
+                    "timestamp": "2026-08-20T10:00:05.000Z",
+                    "message": {
+                        "role": "toolResult",
+                        "toolName": "edit",
+                        "content": [
+                            {"type": "text", "text": "oldText not found", "isError": True}
+                        ],
+                    },
+                },
+            ])
+
+            meta, stats, entries, skills = parse_pi_session(path, {"update-skill"}, False)
+
+            self.assertEqual(meta["id"], "session-1")
+            self.assertEqual(meta["cwd"], "/tmp/repo")
+            self.assertEqual(meta["originator"], "pi")
+            self.assertEqual(stats["user_turns"], 1)
+            self.assertEqual(stats["assistant_turns"], 2)
+            self.assertEqual(stats["tool_calls"], 2)
+            self.assertEqual(stats["repeated_tool_calls"], 0)
+            self.assertEqual(stats["error_outputs"], 1)
+            self.assertTrue(stats["has_code_edits"])
+            self.assertEqual(stats["first_ts"], "2026-08-20T10:00:00.000Z")
+            self.assertEqual(stats["last_ts"], "2026-08-20T10:00:05.000Z")
+            self.assertEqual(skills, ["update-skill"])
+            self.assertIn(("user", "Improve my skill"), entries)
+            self.assertIn(("assistant", "I will inspect it."), entries)
+            self.assertIn(("output", "--- description: alpha"), entries)
+            self.assertFalse(any(role == "thinking" for role, _ in entries))
+
+    def test_accepts_include_subagents_without_changing_result(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "session-2.jsonl"
+            write_jsonl(path, [
+                {"type": "session", "id": "session-2", "cwd": "/tmp/repo",
+                 "timestamp": "2026-08-20T10:00:00.000Z"},
+                {"type": "message", "timestamp": "2026-08-20T10:00:01.000Z",
+                 "message": {"role": "user", "content": "Hello there"}},
+            ])
+
+            without_flag = parse_pi_session(path, set(), False)
+            with_flag = parse_pi_session(path, set(), True)
+
+            self.assertEqual(without_flag, with_flag)
+            self.assertEqual(with_flag[0]["originator"], "pi")
+
+    def test_finds_recent_session_files_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pi_home = Path(tmp)
+            recent = pi_home / "sessions" / "--tmp-repo" / "recent.jsonl"
+            old = pi_home / "sessions" / "--tmp-repo" / "old.jsonl"
+            for path in (recent, old):
+                write_jsonl(path, [{"type": "session", "id": "x"}])
+            old_time = (datetime.now(timezone.utc) - timedelta(days=10)).timestamp()
+            os.utime(old, (old_time, old_time))
+            cutoff = datetime.now(timezone.utc) - timedelta(days=1)
+
+            files = find_pi_session_files(pi_home, cutoff)
+
+            self.assertEqual([path for _, path in files], [recent])
+
+
+class GrokSessionTests(unittest.TestCase):
+    def test_parses_tool_calls_and_skips_synthetic_messages(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            grok_home = Path(tmp)
+            session_dir = grok_home / "sessions" / "%2Ftmp%2Frepo" / "abc-123"
+            path = session_dir / "chat_history.jsonl"
+            write_jsonl(path, [
+                {"type": "system", "content": "You are Grok."},
+                {
+                    "type": "user",
+                    "synthetic_reason": "system_reminder",
+                    "content": [{"type": "text", "text": "<system-reminder>skills</system-reminder>"}],
+                },
+                {"type": "user", "content": "Fix the collector"},
+                {
+                    "type": "reasoning",
+                    "id": "rs-1",
+                    "summary": "[]",
+                    "encrypted_content": "xx",
+                    "status": "completed",
+                },
+                {
+                    "type": "assistant",
+                    "content": "I will read the skill.",
+                    "tool_calls": [{
+                        "id": "call-1",
+                        "name": "read_file",
+                        "arguments": "{\"path\": \"/repo/.grok/skills/update-skill/SKILL.md\"}",
+                    }],
+                },
+                {"type": "tool_result", "tool_call_id": "call-1", "content": "file body"},
+                {
+                    "type": "assistant",
+                    "content": "Now writing the file.",
+                    "tool_calls": [{
+                        "id": "call-2",
+                        "name": "write",
+                        "arguments": "{\"path\": \"/tmp/repo/out.txt\", \"content\": \"hi\"}",
+                    }],
+                },
+            ])
+            cutoff = datetime.now(timezone.utc) - timedelta(days=1)
+
+            files = find_grok_session_files(grok_home, cutoff)
+            self.assertEqual([found for _, found in files], [path])
+
+            meta, stats, entries, skills = parse_grok_session(path, {"update-skill"}, False)
+
+            self.assertEqual(meta["id"], "abc-123")
+            self.assertEqual(meta["cwd"], "/tmp/repo")
+            self.assertEqual(meta["originator"], "grok")
+            self.assertEqual(stats["user_turns"], 1)
+            self.assertEqual(stats["assistant_turns"], 2)
+            self.assertEqual(stats["tool_calls"], 2)
+            self.assertEqual(stats["error_outputs"], 0)
+            self.assertTrue(stats["has_code_edits"])
+            self.assertEqual(skills, ["update-skill"])
+            self.assertEqual(entries[0], ("user", "Fix the collector"))
+            self.assertNotIn("system-reminder", json.dumps(entries))
+
+
+class ZcodeSessionTests(unittest.TestCase):
+    def test_parses_last_request_messages_and_tool_calls(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "model-io-sess_1.jsonl"
+            empty_request = {"request": {"body": {"messages": []}}}
+            full_request = {
+                "request": {
+                    "body": {
+                        "messages": [
+                            {"role": "system", "content": "You are ZCode."},
+                            {"role": "user", "content": "Update the skill"},
+                            {
+                                "role": "assistant",
+                                "content": "Checking.",
+                                "tool_calls": [{
+                                    "id": "c1",
+                                    "function": {
+                                        "name": "read_file",
+                                        "arguments": "{\"path\": \"/r/.agents/skills/update-skill/SKILL.md\"}",
+                                    },
+                                }],
+                            },
+                            {"role": "tool", "content": "skill body"},
+                        ]
+                    }
+                }
+            }
+            path.write_text(
+                json.dumps(empty_request) + "\n" + json.dumps(full_request) + "\n"
+            )
+
+            meta, stats, entries, skills = parse_zcode_session(path, {"update-skill"}, False)
+
+            self.assertEqual(meta["id"], "sess_1")
+            self.assertEqual(meta["originator"], "zcode")
+            self.assertEqual(stats["user_turns"], 1)
+            self.assertEqual(stats["assistant_turns"], 1)
+            self.assertEqual(stats["tool_calls"], 1)
+            self.assertEqual(skills, ["update-skill"])
+            self.assertEqual(entries[0], ("user", "Update the skill"))
+
+    def test_returns_none_without_request_records(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "model-io-sess_2.jsonl"
+            path.write_text("{\"unrelated\": true}\n")
+
+            self.assertIsNone(parse_zcode_session(path, set(), False))
 
 
 if __name__ == "__main__":

--- a/.agents/skills/skill-doctor/scripts/test_collect_sessions.py
+++ b/.agents/skills/skill-doctor/scripts/test_collect_sessions.py
@@ -55,6 +55,37 @@ class ClaudeSessionTests(unittest.TestCase):
                 session_matches_repos(root / "elsewhere", [first, second])
             )
 
+    def test_discovers_global_skills_without_repositories(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            homes = {
+                name: root / f"{name}-home"
+                for name in ("codex", "pi", "grok", "zcode")
+            }
+            for name, home in homes.items():
+                skill = home / "skills" / f"{name}-skill" / "SKILL.md"
+                skill.parent.mkdir(parents=True)
+                skill.write_text(f"---\ndescription: {name.title()} skill\n---\n")
+
+            skills = discover_skills(
+                [],
+                homes["codex"],
+                [],
+                True,
+                pi_home=homes["pi"],
+                grok_home=homes["grok"],
+                zcode_home=homes["zcode"],
+            )
+
+            self.assertTrue(
+                {
+                    "codex-skill",
+                    "pi-skill",
+                    "grok-skill",
+                    "zcode-skill",
+                }.issubset(skills)
+            )
+
     def test_detects_skills_from_deferred_tool_entries(self):
         entries = [
             ("tool:Skill", '{"skill": "alpha"}'),


### PR DESCRIPTION
## Problem

`skill-doctor` only runs inside Warp, Claude Code, and Codex. Pi, Grok Build, and ZCode users hit the startup gate immediately:

> skill-doctor currently supports Warp, Claude Code, and Codex. This run appears to be using an unsupported harness, so no conversations were read.

That blocks grading on machines where Pi and Grok are the daily drivers (e.g. 85 Pi sessions + 341 Grok sessions locally).

## Solution

Add first-class harness support for **Pi**, **Grok Build**, and **ZCode** so `--harness auto` discovers them and `--harness pi|grok|zcode` filters to one source.

### Changes

**`references/supported-harnesses.md`**
- Add collector table rows for `pi` → `~/.pi/agent/sessions`, `grok` → `~/.grok/sessions`, `zcode` → `~/.zcode/cli/rollout`.
- Extend startup-gate message to list all six harnesses.
- Add `--pi-home`, `--grok-home`, `--zcode-home` override flags.
- Extend global skill locations to Pi/Grok/ZCode homes.

**`scripts/collect_sessions.py`**
- New CLI flags `--pi-home` (default `~/.pi/agent`), `--grok-home` (`~/.grok`), `--zcode-home` (`~/.zcode`); extend `--harness` choices to `pi,grok,zcode`.
- `discover_skills()` now scans Pi/Grok/ZCode skill homes when `--include-global-skills` is set.
- New helpers: `find_pi_session_files` / `parse_pi_session`, `find_grok_session_files` / `parse_grok_session`, `find_zcode_session_files` / `parse_zcode_session` — all mirroring the existing Claude/Codex patterns (MAX_FILE_BYTES, look-injected filtering, repeated-call tracking, `skills/{name}/` + `{name}/SKILL.md` detection).
- `main()` wires the three new sources for `auto`/`all`/per-harness runs, with the same `assistant_turns < 1 or tool_calls < 1` scoreability gate and mixed-harness inventory reporting.
- `looks_injected` gains `user_info` (Grok preamble).

**`scripts/test_collect_sessions.py`**
- 6 new tests covering Pi parsing (stats, skill detection, include_subagents no-op, mtime discovery), Grok synthetic-skip + URL-decoded cwd, and ZCode last-request parsing.

### Verification

```
python3 -m py_compile .agents/skills/skill-doctor/scripts/collect_sessions.py  # OK
python3 -m unittest .agents/skills/skill-doctor/scripts/test_collect_sessions  # 11/11 OK (22/22 incl. render)
python3 .agents/skills/skill-doctor/scripts/collect_sessions.py --harness auto --all-conversations --include-global-skills --out /tmp/sd  # Pi 85 + Grok 341 + ZCode 3 + Codex 0 → 12 sampled, mixed
python3 .agents/skills/skill-doctor/scripts/collect_sessions.py --harness grok --all-conversations --out /tmp/sd-grok  # Grok-only smoke ok
python3 .agents/skills/skill-doctor/scripts/collect_sessions.py --harness pi   --all-conversations --out /tmp/sd-pi    # Pi-only smoke ok
```

Existing Claude/Codex/Warp paths and tests are untouched.

### Out of scope

- ZCode sessions have no `cwd` in model-io, so they only appear under `--all-conversations` (consistent with other cwd-less sources).
- Grok chat lines carry no per-line timestamps, so recency uses file mtime.

---

Built and tested from real Pi/Grok/ZCode stores by el Gentleman (Pi harness) + gentle-ai-worker.
