### PR TITLE
feat(collector): Add Hermes Agent harness via state.db

### DIFF
--- a/.agents/skills/skill-doctor/references/supported-harnesses.md
+++ b/.agents/skills/skill-doctor/references/supported-harnesses.md
@@ -12,12 +12,13 @@ This file is the single source of truth for harness support in `skill-doctor`. R
 | Pi | `pi` | Pi agent JSONL (`~/.pi/agent/sessions`) |
 | Grok Build | `grok` | Grok Build chat_history JSONL (`~/.grok/sessions`) |
 | ZCode | `zcode` | ZCode model-io rollout (`~/.zcode/cli/rollout`) |
+| Hermes | `hermes` | Hermes Agent state.db (SQLite: `sessions` + `messages`) |
 
 At startup, identify the harness executing the skill from the runtime context. Do not infer it from conversation files found on disk.
 
 If the executing harness is not listed above, or cannot be identified confidently, stop before creating a report directory or reading conversation history. Tell the user:
 
-> skill-doctor currently supports Warp, Claude Code, Codex, Pi, Grok Build, and ZCode. This run appears to be using an unsupported harness, so no conversations were read.
+> skill-doctor currently supports Warp, Claude Code, Codex, Pi, Grok Build, ZCode, and Hermes. This run appears to be using an unsupported harness, so no conversations were read.
 
 ## Collector source selection
 
@@ -35,6 +36,7 @@ Harness-specific source overrides:
 - `--pi-home PATH` — nonstandard Pi agent home (default `~/.pi/agent`).
 - `--grok-home PATH` — nonstandard Grok Build home (default `~/.grok`).
 - `--zcode-home PATH` — nonstandard ZCode home (default `~/.zcode`).
+- `--hermes-home PATH` — Hermes Agent home containing `state.db` (default: `HERMES_HOME` env or `~`).
 
 ## Skill locations
 

--- a/.agents/skills/skill-doctor/scripts/collect_sessions.py
+++ b/.agents/skills/skill-doctor/scripts/collect_sessions.py
@@ -42,7 +42,7 @@ def parse_args():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument(
         "--harness",
-        choices=("auto", "all", "claude", "codex", "warp", "pi", "grok", "zcode"),
+        choices=("auto", "all", "claude", "codex", "warp", "pi", "grok", "zcode", "hermes"),
         default="auto",
         help="session source (default: auto; scans every locally available source)",
     )
@@ -66,6 +66,11 @@ def parse_args():
         "--zcode-home",
         default="~/.zcode",
         help="ZCode home (default: ~/.zcode)",
+    )
+    p.add_argument(
+        "--hermes-home",
+        default=os.environ.get("HERMES_HOME", "~"),
+        help="Hermes Agent home containing state.db (default: HERMES_HOME or ~)",
     )
     p.add_argument(
         "--warp-db",
@@ -655,6 +660,181 @@ def find_warp_conversations(databases, cutoff):
     records = sorted(newest_by_id.values(), key=lambda row: row["modified_at"], reverse=True)
     return records, scanned
 
+
+def discover_hermes_databases(explicit_path=None):
+    """Find Hermes Agent ``state.db`` files (HERMES_HOME, ~/.hermes, ~)."""
+    roots = []
+    if explicit_path:
+        roots.append(Path(explicit_path).expanduser())
+    env_home = os.environ.get("HERMES_HOME")
+    if env_home:
+        roots.append(Path(env_home).expanduser())
+    roots.append(Path.home() / ".hermes")
+    roots.append(Path.home())
+    seen = set()
+    databases = []
+    for root in roots:
+        candidate = root / "state.db"
+        key = str(candidate)
+        if key in seen or not candidate.is_file():
+            continue
+        seen.add(key)
+        databases.append(candidate)
+    return databases
+
+
+def hermes_database_has_sessions(connection):
+    row = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'sessions'"
+    ).fetchone()
+    return row is not None
+
+
+def parse_epoch_timestamp(value):
+    """Parse a float/int epoch-seconds column into an aware UTC datetime."""
+    if value is None:
+        return None
+    try:
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
+def parse_hermes_session(connection, session_row, skill_names, include_subagents: bool):
+    """Normalize one Hermes Agent session (from state.db) to the shared transcript shape."""
+    if session_row["parent_session_id"] and not include_subagents:
+        return None
+    meta = {
+        "id": session_row["id"],
+        "source": session_row["source"] or "cli",
+        "cwd": session_row["cwd"],
+        "title": session_row["title"] or session_row["display_name"],
+    }
+    stats = {
+        "user_turns": 0,
+        "assistant_turns": 0,
+        "tool_calls": 0,
+        "repeated_tool_calls": 0,
+        "error_outputs": 0,
+    }
+    entries = TranscriptBuffer()
+    seen_calls = {}
+    used_tool_names = set()
+    skills_used = detect_skill_candidates(session_row["cwd"] or "")
+    has_code_edit_hint = False
+    first_ts = last_ts = None
+
+    rows = connection.execute(
+        """
+        SELECT role, content, tool_calls, timestamp
+        FROM messages
+        WHERE session_id = ?
+        ORDER BY timestamp
+        """,
+        (session_row["id"],),
+    ).fetchall()
+    for row in rows:
+        ts = parse_epoch_timestamp(row["timestamp"])
+        if ts is not None:
+            first_ts = first_ts or ts
+            last_ts = ts
+        role = row["role"]
+        tool_calls_raw = row["tool_calls"]
+        content = row["content"] or ""
+        if role == "user" and content.strip():
+            stats["user_turns"] += 1
+            entries.append(("user", truncate(content, MAX_MSG_CHARS)))
+        elif role == "assistant":
+            stats["assistant_turns"] += 1
+            if content.strip():
+                skills_used |= detect_skill_candidates(content) & set(skill_names)
+                entries.append(("assistant", truncate(content, MAX_MSG_CHARS)))
+            if tool_calls_raw:
+                try:
+                    parsed_calls = json.loads(tool_calls_raw)
+                except ValueError:
+                    parsed_calls = []
+                for tc in parsed_calls:
+                    fn = tc.get("function", {}) if isinstance(tc, dict) else {}
+                    tool = fn.get("name") or ""
+                    args = fn.get("arguments") or ""
+                    if not tool:
+                        continue
+                    stats["tool_calls"] += 1
+                    used_tool_names.add(tool)
+                    if tool in CODE_EDIT_HINTS or tool in GENERIC_EDIT_TOOLS:
+                        has_code_edit_hint = True
+                    seen_calls[tool] = seen_calls.get(tool, 0) + 1
+                    for name in detect_skill_candidates(args) & set(skill_names):
+                        skills_used.add(name)
+                    if tool == "skill_view":
+                        try:
+                            payload = json.loads(args) if isinstance(args, str) else args
+                            name = (payload or {}).get("name")
+                            if name in skill_names:
+                                skills_used.add(name)
+                        except (ValueError, TypeError):
+                            pass
+                    entries.append(("tool", f"{tool} {truncate(args, MAX_TOOL_CHARS)}"))
+        elif role == "tool" and content.strip():
+            lowered = content[:200].lower()
+            if "error" in lowered or "traceback" in lowered:
+                stats["error_outputs"] += 1
+            entries.append(("tool_output", truncate(content, MAX_TOOL_CHARS)))
+
+    if stats["assistant_turns"] < 1 or stats["tool_calls"] < 1:
+        return None
+
+    for tool, count in seen_calls.items():
+        if count > 1:
+            stats["repeated_tool_calls"] += count - 1
+
+    meta["timestamp"] = (last_ts or first_ts or datetime.now(tz=timezone.utc)).isoformat()
+    stats["has_code_edits"] = has_code_edit_hint
+    stats["skills"] = sorted(skills_used & set(skill_names))
+    return meta, stats, entries.finish(), sorted(skills_used & set(skill_names))
+
+
+def find_hermes_sessions(databases, cutoff):
+    """Return Hermes session rows (with their database) newer than cutoff, newest first."""
+    records = []
+    scanned = 0
+    cutoff_epoch = cutoff.timestamp()
+    for database in databases:
+        connection = None
+        try:
+            connection = open_warp_database(database)
+            if not hermes_database_has_sessions(connection):
+                continue
+            columns = sqlite_table_columns(connection, "sessions")
+            if "cwd" not in columns:
+                continue
+            rows = connection.execute(
+                """
+                SELECT id, source, cwd, title, display_name, parent_session_id,
+                       started_at, last_activity_at, ended_at
+                FROM sessions
+                WHERE COALESCE(last_activity_at, started_at, ended_at) >= ?
+                ORDER BY COALESCE(last_activity_at, started_at, ended_at) DESC
+                """,
+                (cutoff_epoch,),
+            ).fetchall()
+        except sqlite3.Error as exc:
+            print(f"warning: could not read Hermes database {database}: {exc}", file=sys.stderr)
+            continue
+        finally:
+            if connection is not None:
+                connection.close()
+        scanned += len(rows)
+        for row in rows:
+            records.append((database, row))
+    records.sort(
+        key=lambda pair: parse_epoch_timestamp(
+            pair[1]["last_activity_at"] or pair[1]["started_at"] or pair[1]["ended_at"]
+        ) or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
+    return records, scanned
 
 def load_warp_conversation_data(record):
     """Load task blobs and ai_query fallback metadata for one conversation."""
@@ -1542,9 +1722,48 @@ def main():
         )
         sys.exit(1)
 
+    requested_hermes = args.harness in ("auto", "all", "hermes")
+    hermes_databases = discover_hermes_databases(args.hermes_home if args.harness == "hermes" else None)
+    if requested_hermes and hermes_databases:
+        hermes_records, hermes_scanned = find_hermes_sessions(hermes_databases, cutoff)
+        sources["hermes"] = {
+            "home": str(hermes_databases[0].parent),
+            "records_in_window": len(hermes_records),
+        }
+        scanned_count += hermes_scanned
+        for database, row in hermes_records:
+            connection = open_warp_database(database)
+            try:
+                parsed = parse_hermes_session(connection, row, skills.keys(), args.include_subagents)
+            finally:
+                connection.close()
+            if parsed is None:
+                continue
+            meta, stats, entries, skills_used = parsed
+            if not args.all_conversations and not session_matches_repos(
+                meta.get("cwd"),
+                repos,
+            ):
+                continue
+            in_scope_count += 1
+            if stats["assistant_turns"] < 1 or stats["tool_calls"] < 1:
+                continue
+            sessions.append({
+                "harness": "hermes",
+                "meta": meta,
+                "stats": stats,
+                "skills_used": skills_used,
+                "file": str(database),
+                "modified_at": meta["timestamp"],
+                "_entries": entries,
+            })
+    elif args.harness == "hermes":
+        print(f"error: Hermes state.db not found under {args.hermes_home}", file=sys.stderr)
+        sys.exit(1)
+
     if not sources:
         print(
-            "error: no supported session source found (Claude Code, Codex, Warp, Pi, Grok, or ZCode)",
+            "error: no supported session source found (Claude Code, Codex, Warp, Pi, Grok, ZCode, or Hermes)",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -1626,6 +1845,7 @@ def main():
         "pi_home": str(pi_home) if "pi" in sources else None,
         "grok_home": str(grok_home) if "grok" in sources else None,
         "zcode_home": str(zcode_home) if "zcode" in sources else None,
+        "hermes_home": str(args.hermes_home) if "hermes" in sources else None,
         "warp_databases": [str(path) for path in warp_databases],
         "conversation_scope": conversation_scope,
         "repo": str(repos[0]) if len(repos) == 1 else None,

--- a/.agents/skills/skill-doctor/scripts/test_collect_sessions.py
+++ b/.agents/skills/skill-doctor/scripts/test_collect_sessions.py
@@ -13,10 +13,12 @@ from collect_sessions import (
     discover_skills,
     find_claude_session_files,
     find_grok_session_files,
+    find_hermes_sessions,
     find_pi_session_files,
     parse_claude_session,
     parse_codex_session,
     parse_grok_session,
+    parse_hermes_session,
     parse_pi_session,
     parse_zcode_session,
     session_matches_repos,
@@ -587,6 +589,101 @@ class StreamingSessionReadTests(unittest.TestCase):
             self.assertEqual(entries[100], ("note", "[... 61 entries omitted ...]"))
             self.assertEqual(entries[101], ("assistant", "message-161"))
             self.assertEqual(entries[-1], ("assistant", "message-200"))
+
+
+class HermesCollectorTests(unittest.TestCase):
+    def _make_db(self, root):
+        import sqlite3
+
+        db_path = root / "state.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            """CREATE TABLE sessions (
+                id TEXT, source TEXT, cwd TEXT, title TEXT, display_name TEXT,
+                parent_session_id TEXT, started_at REAL, last_activity_at REAL, ended_at REAL)"""
+        )
+        conn.execute(
+            """CREATE TABLE messages (
+                session_id TEXT, role TEXT, content TEXT, tool_calls TEXT, timestamp REAL)"""
+        )
+        return conn
+
+    def test_parse_hermes_session_extracts_stats_and_skills(self):
+        import sqlite3
+
+        with tempfile.TemporaryDirectory() as tmp:
+            conn = self._make_db(Path(tmp))
+            base = 1_800_000_000.0
+            conn.execute(
+                "INSERT INTO sessions VALUES ('s1','cli','/tmp/repo','t','d',NULL,?,?,?)",
+                (base, base + 60, base + 60),
+            )
+            conn.execute(
+                "INSERT INTO messages VALUES ('s1','user','do the thing',NULL,?)", (base,)
+            )
+            tool_calls = json.dumps([
+                {"function": {"name": "skill_view", "arguments": "{\"name\":\"my-skill\"}"}},
+                {"function": {"name": "terminal", "arguments": "ls"}},
+            ])
+            conn.execute(
+                "INSERT INTO messages VALUES ('s1','assistant','ok',?,?)", (tool_calls, base + 1)
+            )
+            conn.execute(
+                "INSERT INTO messages VALUES ('s1','tool','error: boom',NULL,?)", (base + 2,)
+            )
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM sessions").fetchone()
+
+            parsed = parse_hermes_session(conn, row, {"my-skill"}, False)
+
+            self.assertIsNotNone(parsed)
+            meta, stats, entries, skills_used = parsed
+            self.assertEqual(meta["id"], "s1")
+            self.assertEqual(stats["user_turns"], 1)
+            self.assertEqual(stats["assistant_turns"], 1)
+            self.assertEqual(stats["tool_calls"], 2)
+            self.assertEqual(stats["error_outputs"], 1)
+            self.assertEqual(skills_used, ["my-skill"])
+
+    def test_parse_hermes_session_skips_subagents(self):
+        import sqlite3
+
+        with tempfile.TemporaryDirectory() as tmp:
+            conn = self._make_db(Path(tmp))
+            base = 1_800_000_000.0
+            conn.execute(
+                "INSERT INTO sessions VALUES ('s2','subagent','/tmp',NULL,NULL,'parent',?,?,?)",
+                (base, base, base),
+            )
+            conn.execute(
+                "INSERT INTO messages VALUES ('s2','assistant','hi',?,?)",
+                (json.dumps([{"function": {"name": "terminal", "arguments": "ls"}}]), base),
+            )
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM sessions").fetchone()
+
+            self.assertIsNone(parse_hermes_session(conn, row, set(), False))
+            self.assertIsNotNone(parse_hermes_session(conn, row, set(), True))
+
+    def test_find_hermes_sessions_filters_by_cutoff(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            conn = self._make_db(root)
+            old, new = 1_000_000_000.0, datetime.now(tz=timezone.utc).timestamp()
+            for sid, ts in (("old", old), ("new", new)):
+                conn.execute(
+                    "INSERT INTO sessions VALUES (?,?,?,?,?,NULL,?,?,?)",
+                    (sid, "cli", "/tmp", None, None, ts, ts, ts),
+                )
+            conn.commit()
+            conn.close()
+
+            records, scanned = find_hermes_sessions(
+                [root / "state.db"], datetime.fromtimestamp(new - 60, tz=timezone.utc)
+            )
+
+            self.assertEqual(scanned, 1)
+            self.assertEqual([row["id"] for _, row in records], ["new"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Adds **Hermes Agent** as a skill-doctor session source, closing the gap where Hermes users' local conversations were invisible to /skill-doctor.

## Why

skill-doctor reads local transcripts to grade agent skills, but Hermes Agent stores everything in a local SQLite `state.db` (tables: `sessions`, `messages`) instead of JSONL files. The collector ignored this source entirely.

## How

- `discover_hermes_databases()` — finds `state.db` under `HERMES_HOME`, `~/.hermes`, or explicit `--hermes-home`
- `parse_hermes_session()` — normalizes `sessions`+`messages` rows into the shared transcript shape; detects skill usage from tool-call arguments JSON (incl. explicit `skill_view` payloads)
- `find_hermes_sessions()` — epoch-seconds cutoff filter, newest-first ordering
- Subagent sessions (`parent_session_id`) skipped unless `--include-subagents`
- Read-only SQLite connections (`mode=ro` + `query_only` pragma) — collector never writes
- `--harness hermes` choice + `--hermes-home` flag; docs updated (`supported-harnesses.md`)

## Testing

- 3 new unit tests (parse stats/skills, subagent skip, cutoff filter)
- Full suite: `28 passed` (was 25)
- Live verification against a real Hermes home: 122 sessions in window, skill detection confirmed (skill-vet, graphify, rtk-token-compressor observed in transcripts)

Follows the existing per-harness collector pattern (Warp SQLite collector as template).

Closes #96